### PR TITLE
Better error reporting with wrong spec

### DIFF
--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2005-2016, Ilya Etingof <ilya@glas.net>
 # License: http://pyasn1.sf.net/license.html
 #
-from pyasn1.type import tag, univ, char, useful, tagmap
+from pyasn1.type import base, tag, univ, char, useful, tagmap
 from pyasn1.codec.ber import eoo
 from pyasn1.compat.octets import str2octs, oct2int, isOctetsType
 from pyasn1 import debug, error
@@ -616,6 +616,9 @@ class Decoder:
                  substrateFun=None, allowEoo=False):
         if debug.logger & debug.flagDecoder:
             debug.logger('decoder called at scope %s with state %d, working with up to %d octets of substrate: %s' % (debug.scope, state, len(substrate), debug.hexdump(substrate)))
+        if not isinstance(asn1Spec, base.Asn1Item):
+            raise error.PyAsn1Error('asn1Spec is not valid (should be an instance of an ASN.1 Item)')
+
         fullSubstrate = substrate
         while state != stStop:
             if state == stDecodeTag:

--- a/test/codec/ber/test_decoder.py
+++ b/test/codec/ber/test_decoder.py
@@ -601,6 +601,14 @@ class GuidedSequenceDecoderTestCase(unittest.TestCase):
             ints2octs((48, 128, 5, 0, 36, 128, 4, 4, 113, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 3, 111, 119, 110, 0, 0, 2, 1, 1, 0, 0)), asn1Spec=self.s
             ) == (self.s, null)
 
+    def testBadSpec(self):
+        try:
+            decoder.decode(ints2octs((48, 2, 5, 0)), asn1Spec=None)
+        except PyAsn1Error:
+            pass
+        else:
+            assert 0, 'Invalid asn1Spec accepted'
+
 class ChoiceDecoderTestCase(unittest.TestCase):
     def setUp(self):
         self.s = univ.Choice(componentType=namedtype.NamedTypes(


### PR DESCRIPTION
Make code like:

    decoder.decode(some_data, asn1Spec=SomeType)

raise a better error message (you want SomeType() instead) instead of previous
one (about unbound get_tag() on SomeType).