### PR TITLE
Add method equivalent of x[component]=None

### DIFF
--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -8,6 +8,15 @@ import sys
 from pyasn1.type import constraint, tagmap, tag
 from pyasn1 import error
 
+
+DEFAULT_VALUE_SENTINEL = object()
+
+def default_value():
+    """Get a marker which can be used to set a component to a default value. For
+    example: sequence['element_name'] = default_value()
+    """
+    return DEFAULT_VALUE_SENTINEL
+
 class Asn1Item: pass
 
 class Asn1ItemBase(Asn1Item):

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -750,6 +750,11 @@ class SetOf(base.AbstractConstructedAsn1Item):
 
     def getComponentByPosition(self, idx): return self._componentValues[idx]
     def setComponentByPosition(self, idx, value=None, verifyConstraints=True):
+        # setting the default value can be either done by value None, or by
+        # special sentinel
+        if value is base.DEFAULT_VALUE_SENTINEL:
+            value = None
+
         l = len(self._componentValues)
         if idx >= l:
             self._componentValues = self._componentValues + (idx-l+1)*[None]
@@ -875,6 +880,11 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
                                exactTypes=False,
                                matchTags=True,
                                matchConstraints=True):
+        # setting the default value can be either done by value None, or by
+        # special sentinel
+        if value is base.DEFAULT_VALUE_SENTINEL:
+            value = None
+
         l = len(self._componentValues)
         if idx >= l:
             self._componentValues = self._componentValues + (idx-l+1)*[None]
@@ -1077,6 +1087,11 @@ class Choice(Set):
                 myClone.setComponentByType(tagSet, c.clone())
 
     def setComponentByPosition(self, idx, value=None, verifyConstraints=True):
+        # setting the default value can be either done by value None, or by
+        # special sentinel
+        if value is base.DEFAULT_VALUE_SENTINEL:
+            value = None
+
         l = len(self._componentValues)
         if idx >= l:
             self._componentValues = self._componentValues + (idx-l+1)*[None]

--- a/test/type/test_univ.py
+++ b/test/type/test_univ.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2005-2016, Ilya Etingof <ilya@glas.net>
 # License: http://pyasn1.sf.net/license.html
 #
-from pyasn1.type import univ, tag, constraint, namedtype, namedval, error
+from pyasn1.type import base, univ, tag, constraint, namedtype, namedval, error
 from pyasn1.compat.octets import str2octs, ints2octs
 from pyasn1.error import PyAsn1Error
 from sys import version_info
@@ -492,6 +492,12 @@ class Sequence(unittest.TestCase):
     def testSetComponents(self):
         assert self.s1.clone().setComponents(name='a', nick='b', age=1) == \
             self.s1.setComponentByPosition(0, 'a').setComponentByPosition(1, 'b').setComponentByPosition(2, 1)
+    def testSetToDefault(self):
+        s = self.s1.clone()
+        s.setComponentByPosition(0, base.default_value())
+        s[2] = base.default_value()
+        assert s[0] == univ.OctetString('')
+        assert s[2] == univ.Integer(34)
 
 class SetOf(unittest.TestCase):
     def setUp(self):
@@ -544,6 +550,9 @@ class Set(unittest.TestCase):
         assert self.s1.getComponentPositionByType(
             univ.Null().getTagSet()
             ) == 1
+    def testSetToDefault(self):
+        self.s1.setComponentByName('name', base.default_value())
+        assert self.s1['name'] == univ.OctetString('')
 
 class Choice(unittest.TestCase):
     def setUp(self):
@@ -596,6 +605,9 @@ class Choice(unittest.TestCase):
     def testSetComponentByPosition(self):
         self.s1.setComponentByPosition(0, univ.OctetString('Jim'))
         assert self.s1 == str2octs('Jim')
+    def testSetToDefault(self):
+        self.s1.setComponentByName('sex', base.default_value())
+        assert self.s1['sex'] != None
     def testClone(self):
         self.s1.setComponentByPosition(0, univ.OctetString('abc'))
         s = self.s1.clone()


### PR DESCRIPTION
Add a new method which allows setting a default value to a component.
The following lines are equivalent:

   x.setComponentToDefault(comp)
   x[comp] = None

but the first one is more explicit and raises fewer eyebrows during
code review.