### PR TITLE
Add a toHexString to BitString

### DIFF
--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -284,6 +284,28 @@ class BitString(base.AbstractSimpleAsn1Item):
     def prettyOut(self, value):
         return '\"\'%s\'B\"' % ''.join([str(x) for x in value])
 
+    def toHexString(self):
+        """Convenience method for getting value as a hex string.
+
+        This method will raise an exception in case of bitstrings which are
+        not multiples of 8 in length. It also does not decorate the result in
+        any way. The result can be translated into bytes/str using
+        binascii.unhexlify().
+        """
+        if len(self) % 8 != 0:
+            raise error.PyAsn1Error('Value length is not a multiple of 8')
+
+        result = ""
+        i = 0
+        while i < len(self):
+            byte = 0
+            for x in range(8):
+                byte |= self[i+x] << (7-x)
+            result += "%02X" % (byte,)
+            i += 8
+        return result
+
+
 try:
     all
 except NameError:  # Python 2.4

--- a/test/type/test_univ.py
+++ b/test/type/test_univ.py
@@ -127,6 +127,14 @@ class BitStringTestCase(unittest.TestCase):
         assert self.b.clone("'A98A'H")[0] == 1
         assert self.b.clone("'A98A'H")[1] == 0
         assert self.b.clone("'A98A'H")[2] == 1
+    def testToHexString(self):
+        assert self.b.clone("'A98A'H").toHexString() == 'A98A'
+        try:
+            self.b.clone((1, 0, 1)).toHexString()
+        except PyAsn1Error:
+            pass
+        else:
+            assert 0, "non 8-bit bitstring didn't fail"
         
 class OctetStringTestCase(unittest.TestCase):
     def testInit(self):


### PR DESCRIPTION
Add a helper for use with BitString. In most real-world cases bitstrings will
have a length that's a multiple of 8. Especially in crypto-related use.

Since you can already provide a value like '1234'H to initialise bitstrings,
create a matching serialiser which will give hex output.