### PR TITLE
Use new style classes, instead of an old ones

### DIFF
--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -10,7 +10,7 @@ from pyasn1.compat.octets import str2octs, oct2int, isOctetsType
 from pyasn1 import debug, error
 
 
-class AbstractDecoder:
+class AbstractDecoder(object):
     protoComponent = None
 
     def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
@@ -664,7 +664,7 @@ typeMap = {
  stDumpRawValue, stErrorCondition, stStop) = [x for x in range(10)]
 
 
-class Decoder:
+class Decoder(object):
     defaultErrorState = stErrorCondition
     #    defaultErrorState = stDumpRawValue
     defaultRawDecoder = AnyDecoder()

--- a/pyasn1/codec/ber/encoder.py
+++ b/pyasn1/codec/ber/encoder.py
@@ -14,7 +14,7 @@ class Error(Exception):
     pass
 
 
-class AbstractItemEncoder:
+class AbstractItemEncoder(object):
     supportIndefLenMode = 1
 
     # noinspection PyMethodMayBeStatic
@@ -436,7 +436,7 @@ typeMap = {
 }
 
 
-class Encoder:
+class Encoder(object):
     supportIndefLength = True
 
     # noinspection PyDefaultArgument

--- a/pyasn1/debug.py
+++ b/pyasn1/debug.py
@@ -21,7 +21,7 @@ flagMap = {
 }
 
 
-class Printer:
+class Printer(object):
     # noinspection PyShadowingNames
     def __init__(self, logger=None, handler=None, formatter=None):
         if logger is None:
@@ -52,7 +52,7 @@ else:
             pass
 
 
-class Debug:
+class Debug(object):
     defaultPrinter = None
 
     def __init__(self, *flags, **options):
@@ -112,7 +112,7 @@ def hexdump(octets):
     )
 
 
-class Scope:
+class Scope(object):
     def __init__(self):
         self._list = []
 

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -9,7 +9,7 @@ from pyasn1.type import constraint, tagmap, tag
 from pyasn1 import error
 
 
-class Asn1Item:
+class Asn1Item(object):
     pass
 
 

--- a/pyasn1/type/constraint.py
+++ b/pyasn1/type/constraint.py
@@ -10,7 +10,7 @@ import sys
 from pyasn1.type import error
 
 
-class AbstractConstraint:
+class AbstractConstraint(object):
     """Abstract base-class for constraint objects
 
        Constraints should be stored in a simple sequence in the

--- a/pyasn1/type/namedtype.py
+++ b/pyasn1/type/namedtype.py
@@ -9,7 +9,7 @@ from pyasn1.type import tagmap
 from pyasn1 import error
 
 
-class NamedType:
+class NamedType(object):
     """Named type specification for constructed types
     """
     isOptional = 0
@@ -67,7 +67,7 @@ class DefaultedNamedType(NamedType):
     isDefaulted = 1
 
 
-class NamedTypes:
+class NamedTypes(object):
     def __init__(self, *namedTypes):
         self.__namedTypes = namedTypes
         self.__namedTypesLen = len(self.__namedTypes)

--- a/pyasn1/type/namedval.py
+++ b/pyasn1/type/namedval.py
@@ -11,7 +11,7 @@ from pyasn1 import error
 __all__ = ['NamedValues']
 
 
-class NamedValues:
+class NamedValues(object):
     def __init__(self, *namedValues):
         self.nameToValIdx = {}
         self.valToNameIdx = {}

--- a/pyasn1/type/tag.py
+++ b/pyasn1/type/tag.py
@@ -20,7 +20,7 @@ tagCategoryExplicit = 0x02
 tagCategoryUntagged = 0x04
 
 
-class Tag:
+class Tag(object):
     """ASN.1 types tags"""
 
     def __init__(self, tagClass, tagFormat, tagId):
@@ -84,7 +84,7 @@ class Tag:
         return self.__tag  # __getitem__() is slow
 
 
-class TagSet:
+class TagSet(object):
     def __init__(self, baseTag=(), *superTags):
         self.__baseTag = baseTag
         self.__superTags = superTags

--- a/pyasn1/type/tagmap.py
+++ b/pyasn1/type/tagmap.py
@@ -7,7 +7,7 @@
 from pyasn1 import error
 
 
-class TagMap:
+class TagMap(object):
     # noinspection PyDefaultArgument
     def __init__(self, posMap={}, negMap={}, defType=None):
         self.__posMap = posMap.copy()


### PR DESCRIPTION
Old style classes prohibits using of, for example,
typing.cast(Sequence[X509Sequence], ...) casting, which checks whether
X509Sequence is a "type" (old style classes have "classobj" type).