### PR TITLE
fix doc creation on py2

### DIFF
--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -133,7 +133,8 @@ class NoValue(object):
     a PyASN1 type object.
     """
     skipMethods = ('__getattribute__', '__getattr__', '__setattr__', '__delattr__',
-                   '__class__', '__init__', '__del__', '__new__', '__repr__', '__qualname__')
+                   '__class__', '__init__', '__del__', '__new__', '__repr__', 
+                   '__qualname__', '__objclass__', 'im_class')
 
     _instance = None
 


### PR DESCRIPTION
sphinx.ext.napoleon uses '__objclass__', 'im_class' on py2 instead of '__qualname__'.