### PR TITLE
Avoid returning None in Set.getComponentTagMap.

### DIFF
--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -2144,7 +2144,8 @@ class Set(SequenceAndSetBase):
     def getComponentTagMap(self):
         if self._componentType:
             return self._componentType.getTagMap(True)
-
+        return tagmap.TagMap()
+        
     def getComponentPositionByType(self, tagSet):
         if self._componentType:
             return self._componentType.getPositionByType(tagSet)

--- a/test/type/test_univ.py
+++ b/test/type/test_univ.py
@@ -865,12 +865,14 @@ class Set(unittest.TestCase):
             namedtype.DefaultedNamedType('age', univ.Integer(34))
         ))
         self.s2 = self.s1.clone()
+        self.s3 = univ.Set(componentType=None)
 
     def testTag(self):
         assert self.s1.getTagSet() == tag.TagSet(
             (),
             tag.Tag(tag.tagClassUniversal, tag.tagFormatConstructed, 0x11)
         ), 'wrong tagSet'
+        assert self.s3.getComponentTagMap() is not None
 
     def testByTypeWithPythonValue(self):
         self.s1.setComponentByType(univ.OctetString.tagSet, 'abc')


### PR DESCRIPTION
Return empty TagMap as a fallback.

Related to cannatag/ldap3#255