### PR TITLE
Fix to NamedTypes methods to handle .getTagMap() returning None

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,6 +26,7 @@ Revision 0.1.10, released XX-XX-2016
   constraints are wrapped in ConstraintsIntersection composite, additional
   constraints being added on subtyping effectively further narrow the set of
   allowed values, which aligns well with the notion of subtyping.
+- Fix to NamedTypes methods to handle .getTagMap() returning None
 
 Revision 0.1.9, released 28-09-2015
 -----------------------------------

--- a/pyasn1/type/namedtype.py
+++ b/pyasn1/type/namedtype.py
@@ -131,7 +131,7 @@ class NamedTypes(object):
             idx = self.__namedTypesLen
             while idx > 0:
                 idx -= 1
-                tagMap = self.__namedTypes[idx].getType().getTagMap()
+                tagMap = self.__namedTypes[idx].getType().getTagMap() or tagmap.TagMap()
                 for t in tagMap.getPosMap():
                     if t in self.__tagToPosIdx:
                         raise error.PyAsn1Error('Duplicate type %s' % (t,))
@@ -203,7 +203,7 @@ class NamedTypes(object):
             tagMap = tagmap.TagMap()
             for nt in self.__namedTypes:
                 tagMap = tagMap.clone(
-                    nt.getType(), nt.getType().getTagMap(), uniq
+                    nt.getType(), nt.getType().getTagMap() or tagmap.TagMap(), uniq
                 )
             self.__tagMap[uniq] = tagMap
         return self.__tagMap[uniq]


### PR DESCRIPTION
Following up [this issue](https://github.com/etingof/pyasn1/pull/12).