### PR TITLE
Automatically instantiate constructed types components

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,17 @@ Revision 0.2.4, released XX-03-2017
 - The .hasValue() method refactored into .isValue property
 - Codecs lookup made more efficient at BER/CER/DER decoder main loop by
   assigning `typeId` to every ASN.1 type, not just ambiguous ones.
+- The .getComponent*() methods of constructed ASN.1 types changed
+  to lazily instantiate underlying type rather than return `None`.
+  This should simplify its API as initialization like `X[0][1] = 2` becomes
+  possible. Beware that this change introduces a deviation from
+  original API.
+- The .setComponent*() methods of SetOf/SequenceOf types changed not
+  to allow uninitialized "holes" inside the sequences of their components.
+  They now behave sililarily to Python lists. Beware that this change
+  introduces a deviation from original API.
+- Default and optional components en/decoding of Constructed type
+  refactored towards better efficiency and more control.
 
 Revision 0.2.3, released 25-02-2017
 -----------------------------------

--- a/pyasn1/codec/ber/encoder.py
+++ b/pyasn1/codec/ber/encoder.py
@@ -338,16 +338,15 @@ class RealEncoder(AbstractItemEncoder):
 
 class SequenceEncoder(AbstractItemEncoder):
     def encodeValue(self, encodeFun, value, defMode, maxChunkSize):
-        value.setDefaultComponents()
         value.verifySizeSpec()
+        namedTypes = value.getComponentType()
         substrate = null
         idx = len(value)
         while idx > 0:
             idx -= 1
-            if value.getComponentByPosition(idx) is None:  # Optional component
+            if namedTypes[idx].isOptional and not value[idx].isValue:
                 continue
-            component = value.getDefaultComponentByPosition(idx)
-            if component is not None and component == value[idx]:
+            if namedTypes[idx].isDefaulted and value[idx] == namedTypes[idx].asn1Object:
                 continue
             substrate = encodeFun(value[idx], defMode, maxChunkSize) + substrate
         return substrate, True, True

--- a/pyasn1/codec/cer/encoder.py
+++ b/pyasn1/codec/cer/encoder.py
@@ -86,8 +86,6 @@ class UTCTimeEncoder(encoder.OctetStringEncoder):
 
 class SetOfEncoder(encoder.SequenceOfEncoder):
     def encodeValue(self, encodeFun, client, defMode, maxChunkSize):
-        if isinstance(client, univ.SequenceAndSetBase):
-            client.setDefaultComponents()
         client.verifySizeSpec()
         substrate = null
         idx = len(client)
@@ -95,12 +93,13 @@ class SetOfEncoder(encoder.SequenceOfEncoder):
         # from Set if they have the same tags&constraints?
         if isinstance(client, univ.SequenceAndSetBase):
             # Set
+            namedTypes = client.getComponentType()
             comps = []
             while idx > 0:
                 idx -= 1
-                if client[idx] is None:  # Optional component
+                if namedTypes[idx].isOptional and not client[idx].isValue:
                     continue
-                if client.getDefaultComponentByPosition(idx) == client[idx]:
+                if namedTypes[idx].isDefaulted and client[idx] == namedTypes[idx].asn1Object:
                     continue
                 comps.append(client[idx])
             comps.sort(key=lambda x: isinstance(x, univ.Choice) and x.getMinTagSet() or x.tagSet)

--- a/pyasn1/codec/native/encoder.py
+++ b/pyasn1/codec/native/encoder.py
@@ -76,11 +76,11 @@ class RealEncoder(AbstractItemEncoder):
 class SetEncoder(AbstractItemEncoder):
     protoDict = dict
     def encode(self, encodeFun, value):
-        value.setDefaultComponents()
         value.verifySizeSpec()
+        namedTypes = value.getComponentType()
         substrate = self.protoDict()
-        for key, subValue in value.items():
-            if subValue is None:  # Optional component
+        for idx, (key, subValue) in enumerate(value.items()):
+            if namedTypes[idx].isOptional and not value[idx].isValue:
                 continue
             substrate[key] = encodeFun(subValue)
         return substrate

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -446,7 +446,6 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
         else:
             self._sizeSpec = sizeSpec
         self._componentValues = []
-        self._componentValuesSet = 0
 
     def __repr__(self):
         representation = []
@@ -588,6 +587,7 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
     def getComponentType(self):
         return self._componentType
 
+    # backward compatibility -- no-op
     def setDefaultComponents(self):
         pass
 
@@ -606,7 +606,6 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
 
     def clear(self):
         self._componentValues = []
-        self._componentValuesSet = 0
 
     # backward compatibility
     def getComponentTagMap(self):

--- a/pyasn1/type/namedtype.py
+++ b/pyasn1/type/namedtype.py
@@ -115,6 +115,7 @@ class NamedTypes(object):
         self.__ambigiousTypesImpl = None
         self.__tagMap = {}
         self.__hasOptionalOrDefault = None
+        self.__requiredComponents = None
 
     def __repr__(self):
         return '%s(%s)' % (
@@ -460,3 +461,15 @@ class NamedTypes(object):
         if self.__hasOptionalOrDefault is None:
             self.__hasOptionalOrDefault = bool([True for namedType in self.__namedTypes if namedType.isDefaulted or namedType.isOptional])
         return self.__hasOptionalOrDefault
+
+    @property
+    def namedTypes(self):
+        return iter(self.__namedTypes)
+
+    @property
+    def requiredComponents(self):
+        if self.__requiredComponents is None:
+            self.__requiredComponents = frozenset(
+                [idx for idx, nt in enumerate(self.__namedTypes) if not nt.isOptional and not nt.isDefaulted]
+            )
+        return self.__requiredComponents

--- a/tests/codec/ber/test_decoder.py
+++ b/tests/codec/ber/test_decoder.py
@@ -480,7 +480,6 @@ class SequenceDecoderTestCase(unittest.TestCase):
         self.s.setComponentByPosition(0, univ.Null(null))
         self.s.setComponentByPosition(1, univ.OctetString('quick brown'))
         self.s.setComponentByPosition(2, univ.Integer(1))
-        self.s.setDefaultComponents()
 
     def testWithOptionalAndDefaultedDefMode(self):
         assert decoder.decode(
@@ -541,26 +540,22 @@ class GuidedSequenceDecoderTestCase(unittest.TestCase):
     def __init(self):
         self.s.clear()
         self.s.setComponentByPosition(0, univ.Null(null))
-        self.s.setDefaultComponents()
 
     def __initWithOptional(self):
         self.s.clear()
         self.s.setComponentByPosition(0, univ.Null(null))
         self.s.setComponentByPosition(1, univ.OctetString('quick brown'))
-        self.s.setDefaultComponents()
 
     def __initWithDefaulted(self):
         self.s.clear()
         self.s.setComponentByPosition(0, univ.Null(null))
         self.s.setComponentByPosition(2, univ.Integer(1))
-        self.s.setDefaultComponents()
 
     def __initWithOptionalAndDefaulted(self):
         self.s.clear()
         self.s.setComponentByPosition(0, univ.Null(null))
         self.s.setComponentByPosition(1, univ.OctetString('quick brown'))
         self.s.setComponentByPosition(2, univ.Integer(1))
-        self.s.setDefaultComponents()
 
     def testDefMode(self):
         self.__init()

--- a/tests/codec/ber/test_encoder.py
+++ b/tests/codec/ber/test_encoder.py
@@ -343,8 +343,8 @@ class UTF8StringEncoderTestCase(unittest.TestCase):
 class SequenceEncoderTestCase(unittest.TestCase):
     def setUp(self):
         self.s = univ.Sequence(componentType=namedtype.NamedTypes(
-            namedtype.NamedType('place-holder', univ.Null('')),
-            namedtype.OptionalNamedType('first-name', univ.OctetString('')),
+            namedtype.NamedType('place-holder', univ.Null()),
+            namedtype.OptionalNamedType('first-name', univ.OctetString()),
             namedtype.DefaultedNamedType('age', univ.Integer(33)),
         ))
 
@@ -359,7 +359,7 @@ class SequenceEncoderTestCase(unittest.TestCase):
 
     def __initWithDefaulted(self):
         self.s.clear()
-        self.s.setComponentByPosition(0)
+        self.s.setComponentByPosition(0, '')
         self.s.setComponentByPosition(2, 1)
 
     def __initWithOptionalAndDefaulted(self):

--- a/tests/codec/cer/test_encoder.py
+++ b/tests/codec/cer/test_encoder.py
@@ -50,7 +50,7 @@ class SetEncoderTestCase(unittest.TestCase):
     def setUp(self):
         self.s = univ.Set(componentType=namedtype.NamedTypes(
             namedtype.NamedType('place-holder', univ.Null('')),
-            namedtype.OptionalNamedType('first-name', univ.OctetString('')),
+            namedtype.OptionalNamedType('first-name', univ.OctetString()),
             namedtype.DefaultedNamedType('age', univ.Integer(33))
         ))
 

--- a/tests/codec/der/test_encoder.py
+++ b/tests/codec/der/test_encoder.py
@@ -49,16 +49,16 @@ class BitStringEncoderTestCase(unittest.TestCase):
 class SetWithChoiceEncoderTestCase(unittest.TestCase):
     def setUp(self):
         c = univ.Choice(componentType=namedtype.NamedTypes(
-            namedtype.NamedType('name', univ.OctetString('')),
+            namedtype.NamedType('name', univ.OctetString()),
             namedtype.NamedType('amount', univ.Integer(0)))
         )
         self.s = univ.Set(componentType=namedtype.NamedTypes(
-            namedtype.NamedType('place-holder', univ.Null('')),
+            namedtype.NamedType('place-holder', univ.Null()),
             namedtype.NamedType('status', c))
         )
 
     def testDefMode(self):
-        self.s.setComponentByPosition(0)
+        self.s.setComponentByPosition(0, '')
         self.s.setComponentByName('status')
         self.s.getComponentByName('status').setComponentByPosition(0, 'ann')
         assert encoder.encode(self.s) == ints2octs((49, 7, 4, 3, 97, 110, 110, 5, 0))

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -929,17 +929,10 @@ class Sequence(unittest.TestCase):
             univ.OctetString.tagSet, 1
         ) == 1
 
-    def testGetDefaultComponentByPosition(self):
-        self.s1.clear()
-        assert self.s1.getDefaultComponentByPosition(0) is None
-        assert self.s1.getDefaultComponentByPosition(2) == univ.Integer(34)
-
     def testSetDefaultComponents(self):
         self.s1.clear()
-        assert self.s1.getComponentByPosition(2) is None
         self.s1.setComponentByPosition(0, univ.OctetString('Ping'))
         self.s1.setComponentByPosition(1, univ.OctetString('Pong'))
-        self.s1.setDefaultComponents()
         assert self.s1.getComponentByPosition(2) == 34
 
     def testClone(self):
@@ -1019,7 +1012,7 @@ class Sequence(unittest.TestCase):
 
     def testUpdate(self):
         self.s1.clear()
-        assert list(self.s1.values()) == [None, None, None]
+        assert list(self.s1.values()) == [str2octs(''), str2octs(''), 34]
         self.s1.update(**{'name': 'abc', 'nick': 'def', 'age': 123})
         assert list(self.s1.items()) == [(x[0], str2octs(x[1])) for x in [('name', 'abc'), ('nick', 'def')]] + [('age', 123)]
         self.s1.update(('name', 'ABC'))


### PR DESCRIPTION
* .getComponent*() changed to lazily instantiate underlying type on first read access
 * SetOf/SequenceOf types can not have "holes" anymore
 * optional/default components of constructed types refactored for better efficiency and flexibility.