### PR TITLE
Time types datetime support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Revision 0.2.4, released XX-03-2017
 - OctetsString and Any decoder optimized to avoid creating ASN.1
   objects for chunks of substrate. Instead they now join substrate
   chunks together and create ASN.1 object from it just once.
+- The GeneralizedTime and UTCTime types now support to/from Python
+  datetime object conversion.
 - Unit tests added for the `compat` sub-package.
 - Fixed BitString named bits initialization bug.
 - Fixed non-functional tag cache (when running Python 2) at DER decoder.

--- a/doc/source/docs/type/useful/generalizedtime.rst
+++ b/doc/source/docs/type/useful/generalizedtime.rst
@@ -7,13 +7,27 @@
 ------------
 
 .. autoclass:: pyasn1.type.useful.GeneralizedTime(value=NoValue(), tagSet=TagSet(), subtypeSpec=ConstraintsIntersection(), encoding='us-ascii')
-   :members: isValue, isSameTypeWith, isSuperTypeOf, tagSet
+   :members: isValue, isSameTypeWith, isSuperTypeOf, tagSet, asDateTime, fromDateTime
 
    .. note::
 
 
        The |ASN.1| type models a character string representing date and time in many different
        formats. For example, *20170126120000Z* stands for YYYYMMDDHHMMSSZ.
+
+       Formal syntax for the *GeneralizedTime* value is:
+
+       * **YYYYMMDDhh[mm[ss[(.|,)ffff]]]** standing for a local time, four
+         digits for the year, two for the month, two for the day and two
+         for the hour, followed by two digits for the minutes and two
+         for the seconds if required, then a dot (or a comma), and a
+         number for the fractions of second or
+
+       * a string as above followed by the letter “Z” (denoting a UTC
+         time) or
+
+       * a string as above followed by a string **(+|-)hh[mm]** denoting
+         time zone offset
 
    .. automethod:: pyasn1.type.useful.GeneralizedTime.clone(self, value=NoValue(), tagSet=TagSet(), subtypeSpec=ConstraintsIntersection(), encoding='us-ascii')
    .. automethod:: pyasn1.type.useful.GeneralizedTime.subtype(self, value=NoValue(), implicitTag=TagSet(), explicitTag=TagSet(),subtypeSpec=ConstraintsIntersection(), encoding='us-ascii')

--- a/doc/source/docs/type/useful/generalizedtime.rst
+++ b/doc/source/docs/type/useful/generalizedtime.rst
@@ -12,8 +12,8 @@
    .. note::
 
 
-       The |ASN.1| type models a character string representing date and time in many different
-       formats. For example, *20170126120000Z* stands for YYYYMMDDHHMMSSZ.
+       The |ASN.1| type models a character string representing date and time
+       in many different formats.
 
        Formal syntax for the *GeneralizedTime* value is:
 
@@ -27,7 +27,9 @@
          time) or
 
        * a string as above followed by a string **(+|-)hh[mm]** denoting
-         time zone offset
+         time zone offset relative to UTC
+
+       For example, *20170126120000Z* stands for YYYYMMDDHHMMSSZ.
 
    .. automethod:: pyasn1.type.useful.GeneralizedTime.clone(self, value=NoValue(), tagSet=TagSet(), subtypeSpec=ConstraintsIntersection(), encoding='us-ascii')
    .. automethod:: pyasn1.type.useful.GeneralizedTime.subtype(self, value=NoValue(), implicitTag=TagSet(), explicitTag=TagSet(),subtypeSpec=ConstraintsIntersection(), encoding='us-ascii')

--- a/doc/source/docs/type/useful/utctime.rst
+++ b/doc/source/docs/type/useful/utctime.rst
@@ -7,12 +7,26 @@
 ------------
 
 .. autoclass:: pyasn1.type.useful.UTCTime(value=NoValue(), tagSet=TagSet(), subtypeSpec=ConstraintsIntersection(), encoding='us-ascii')
-   :members: isValue, isSameTypeWith, isSuperTypeOf, tagSet
+   :members: isValue, isSameTypeWith, isSuperTypeOf, tagSet, asDateTime, fromDateTime
 
    .. note::
 
-       The |ASN.1| type models a character string representing date and time. An example
-       format is *170126120000Z* which stands for YYMMDDHHMMSSZ.
+       The |ASN.1| type models a character string representing date and time.
+
+       Formal syntax for the *UTCTime* value is:
+
+       * **YYMMDDhhmm[ss]** standing for UTC time, two
+         digits for the year, two for the month, two for the day and two
+         for the hour, followed by two digits for the minutes and two
+         for the seconds if required or
+
+       * a string as above followed by the letter “Z” (denoting a UTC
+         time) or
+
+       * a string as above followed by a string **(+|-)hhmm** denoting
+         time zone offset relative to UTC
+
+       For example, *170126120000Z* which stands for YYMMDDHHMMSSZ.
 
    .. automethod:: pyasn1.type.useful.UTCTime.clone(self, value=NoValue(), tagSet=TagSet(), subtypeSpec=ConstraintsIntersection(), encoding='us-ascii')
    .. automethod:: pyasn1.type.useful.UTCTime.subtype(self, value=NoValue(), implicitTag=TagSet(), explicitTag=TagSet(),subtypeSpec=ConstraintsIntersection(), encoding='us-ascii')

--- a/pyasn1/type/useful.py
+++ b/pyasn1/type/useful.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
 # License: http://pyasn1.sf.net/license.html
 #
+import datetime
 from pyasn1.type import univ, char, tag
 
 __all__ = ['ObjectDescriptor', 'GeneralizedTime', 'UTCTime']
@@ -21,7 +22,40 @@ class ObjectDescriptor(char.GraphicString):
     )
 
 
-class GeneralizedTime(char.VisibleString):
+class TimeMixIn(object):
+    class FixedOffset(datetime.tzinfo):
+        """Fixed offset in minutes east from UTC."""
+
+        def __init__(self, offset, name):
+            self.__offset = datetime.timedelta(minutes=offset)
+            self.__name = name
+
+        def utcoffset(self, dt):
+            return self.__offset
+
+        def tzname(self, dt):
+            return self.__name
+
+        def dst(self, dt):
+            return datetime.timedelta(0)
+
+    @property
+    def asDateTime(self):
+        string = str(self)
+        if string.endswith('Z'):
+            string = string[:-2]
+        return datetime.datetime.strptime(string, '%Y%m%d%H%M%S.%f%z')
+
+    @classmethod
+    def fromDateTime(cls, dt):
+        string = dt.strftime('%Y%m%d%H%M%S.%%d%z')
+        string = '%s.%.2d' % (string, dt.microsecond // 10000)
+        if '+' not in string:
+            string += 'Z'
+        return cls(string)
+
+
+class GeneralizedTime(char.VisibleString, TimeMixIn):
     __doc__ = char.GraphicString.__doc__
 
     #: Default :py:class:`~pyasn1.type.tag.TagSet` object for |ASN.1| objects
@@ -30,7 +64,7 @@ class GeneralizedTime(char.VisibleString):
     )
 
 
-class UTCTime(char.VisibleString):
+class UTCTime(char.VisibleString, TimeMixIn):
     __doc__ = char.GraphicString.__doc__
 
     #: Default :py:class:`~pyasn1.type.tag.TagSet` object for |ASN.1| objects

--- a/pyasn1/type/useful.py
+++ b/pyasn1/type/useful.py
@@ -54,6 +54,7 @@ class TimeMixIn(object):
             string = string[:-1]
 
         elif string[-5] in ('-', '+'):
+            # TODO: handle the case of missing MM
             try:
                 minutes = int(string[-4:-2]) * 60 + int(string[-2:])
                 if string[-5] == '-':

--- a/pyasn1/type/useful.py
+++ b/pyasn1/type/useful.py
@@ -88,7 +88,11 @@ class TimeMixIn(object):
         elif len(string) - self.yearsDigits == 8:
             string += '00'
 
-        dt = datetime.datetime.strptime(string, self.yearsDigits == 4 and '%Y%m%d%H%M%S' or '%y%m%d%H%M%S')
+        try:
+            dt = datetime.datetime.strptime(string, self.yearsDigits == 4 and '%Y%m%d%H%M%S' or '%y%m%d%H%M%S')
+
+        except ValueError:
+            raise error.PyAsn1Error('malformed datetime format %s' % self)
 
         return dt.replace(microsecond=ms, tzinfo=tzinfo)
 

--- a/pyasn1/type/useful.py
+++ b/pyasn1/type/useful.py
@@ -6,6 +6,7 @@
 #
 import datetime
 from pyasn1.type import univ, char, tag
+from pyasn1 import error
 
 __all__ = ['ObjectDescriptor', 'GeneralizedTime', 'UTCTime']
 
@@ -43,20 +44,39 @@ class TimeMixIn(object):
     def asDateTime(self):
         string = str(self)
         if string.endswith('Z'):
-            string = string[:-2]
-        return datetime.datetime.strptime(string, '%Y%m%d%H%M%S.%f%z')
+            tzinfo = TimeMixIn.FixedOffset(0, 'UTC')
+            string = string[:-1]
+
+        elif string[-5] == '+':
+            try:
+                minutes = int(string[-4:]) * 60
+            except ValueError:
+                raise error.PyAsn1Error('unknown time specification %s' % self)
+
+            tzinfo = TimeMixIn.FixedOffset(minutes, '?')
+            string = string[:-5]
+
+        else:
+            tzinfo = None
+
+        dt = datetime.datetime.strptime(string, '%Y%m%d%H%M%S.%f')
+        dt.replace(tzinfo=tzinfo)
+
+        return dt
 
     @classmethod
     def fromDateTime(cls, dt):
-        string = dt.strftime('%Y%m%d%H%M%S.%%d%z')
-        string = '%s.%.2d' % (string, dt.microsecond // 10000)
-        if '+' not in string:
+        string = dt.strftime('%Y%m%d%H%M%S.%%d')
+        string = string % (dt.microsecond // 10000)
+        if dt.utcoffset():
+            string += '+%.4d' % (dt.utcoffset() // 60)
+        else:
             string += 'Z'
         return cls(string)
 
 
 class GeneralizedTime(char.VisibleString, TimeMixIn):
-    __doc__ = char.GraphicString.__doc__
+    __doc__ = char.VisibleString.__doc__
 
     #: Default :py:class:`~pyasn1.type.tag.TagSet` object for |ASN.1| objects
     tagSet = char.VisibleString.tagSet.tagImplicitly(
@@ -65,7 +85,7 @@ class GeneralizedTime(char.VisibleString, TimeMixIn):
 
 
 class UTCTime(char.VisibleString, TimeMixIn):
-    __doc__ = char.GraphicString.__doc__
+    __doc__ = char.VisibleString.__doc__
 
     #: Default :py:class:`~pyasn1.type.tag.TagSet` object for |ASN.1| objects
     tagSet = char.VisibleString.tagSet.tagImplicitly(

--- a/tests/type/__main__.py
+++ b/tests/type/__main__.py
@@ -16,7 +16,8 @@ suite = unittest.TestLoader().loadTestsFromNames(
      'tests.type.test_namedval.suite',
      'tests.type.test_tag.suite',
      'tests.type.test_univ.suite',
-     'tests.type.test_char.suite']
+     'tests.type.test_char.suite',
+     'tests.type.test_useful.suite']
 )
 
 

--- a/tests/type/test_useful.py
+++ b/tests/type/test_useful.py
@@ -40,19 +40,20 @@ class ObjectDescriptorTestCase(unittest.TestCase):
 class GeneralizedTimeTestCase(unittest.TestCase):
 
     def testFromDateTime(self):
-        assert useful.GeneralizedTime.fromDateTime(datetime.datetime(2017, 07, 11, 0, 1, 2, 30000, tzinfo=UTC)) == '20170711000102.3Z'
+        assert useful.GeneralizedTime.fromDateTime(datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC)) == '20170711000102.3Z'
 
     def testToDateTime(self):
-        assert datetime.datetime(2017, 07, 11, 0, 1, 2, 30000, tzinfo=UTC) == useful.GeneralizedTime('20170711000102.3Z').asDateTime
+        assert datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC) == useful.GeneralizedTime('20170711000102.3Z').asDateTime
 
 
 class UTCTimeTestCase(unittest.TestCase):
 
+
     def testFromDateTime(self):
-        assert useful.UTCTime.fromDateTime(datetime.datetime(2017, 07, 11, 0, 1, 2, 3, tzinfo=UTC)) == '2017071100010203,4+0000'
+        assert useful.UTCTime.fromDateTime(datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC)) == '20170711000102.3Z'
 
     def testToDateTime(self):
-        assert datetime.datetime(2017, 07, 11, 0, 1, 2, 3, tzinfo=UTC) == useful.UTCTime('2017071100010203,4+0000')
+        assert datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC) == useful.UTCTime('20170711000102.3Z').asDateTime
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/type/test_useful.py
+++ b/tests/type/test_useful.py
@@ -62,9 +62,12 @@ class GeneralizedTimeTestCase(unittest.TestCase):
         assert datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC2) == useful.GeneralizedTime('20170711000102.3+0200').asDateTime
 
     def testToDateTime6(self):
-        assert datetime.datetime(2017, 7, 11, 0, 1) == useful.GeneralizedTime('201707110001').asDateTime
+        assert datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC2) == useful.GeneralizedTime('20170711000102.3+02').asDateTime
 
     def testToDateTime7(self):
+        assert datetime.datetime(2017, 7, 11, 0, 1) == useful.GeneralizedTime('201707110001').asDateTime
+
+    def testToDateTime8(self):
         assert datetime.datetime(2017, 7, 11, 0) == useful.GeneralizedTime('2017071100').asDateTime
 
 
@@ -87,10 +90,6 @@ class UTCTimeTestCase(unittest.TestCase):
 
     def testToDateTime4(self):
         assert datetime.datetime(2017, 7, 11, 0, 1) == useful.UTCTime('1707110001').asDateTime
-
-    def testToDateTime5(self):
-        assert datetime.datetime(2017, 7, 11, 0) == useful.UTCTime('17071100').asDateTime
-
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 

--- a/tests/type/test_useful.py
+++ b/tests/type/test_useful.py
@@ -16,7 +16,6 @@ except ImportError:
 
 
 class FixedOffset(datetime.tzinfo):
-
     def __init__(self, offset, name):
         self.__offset = datetime.timedelta(minutes=offset)
         self.__name = name
@@ -32,28 +31,65 @@ class FixedOffset(datetime.tzinfo):
 
 
 UTC = FixedOffset(0, 'UTC')
+UTC2 = FixedOffset(120, 'UTC')
 
 
 class ObjectDescriptorTestCase(unittest.TestCase):
     pass
+
 
 class GeneralizedTimeTestCase(unittest.TestCase):
 
     def testFromDateTime(self):
         assert useful.GeneralizedTime.fromDateTime(datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC)) == '20170711000102.3Z'
 
-    def testToDateTime(self):
+    def testToDateTime0(self):
+        assert datetime.datetime(2017, 7, 11, 0, 1, 2) == useful.GeneralizedTime('20170711000102').asDateTime
+
+    def testToDateTime1(self):
+        assert datetime.datetime(2017, 7, 11, 0, 1, 2, tzinfo=UTC) == useful.GeneralizedTime('20170711000102Z').asDateTime
+
+    def testToDateTime2(self):
         assert datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC) == useful.GeneralizedTime('20170711000102.3Z').asDateTime
+
+    def testToDateTime3(self):
+        assert datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC) == useful.GeneralizedTime('20170711000102,3Z').asDateTime
+
+    def testToDateTime4(self):
+        assert datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC) == useful.GeneralizedTime('20170711000102.3+0000').asDateTime
+
+    def testToDateTime5(self):
+        assert datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC2) == useful.GeneralizedTime('20170711000102.3+0200').asDateTime
+
+    def testToDateTime6(self):
+        assert datetime.datetime(2017, 7, 11, 0, 1) == useful.GeneralizedTime('201707110001').asDateTime
+
+    def testToDateTime7(self):
+        assert datetime.datetime(2017, 7, 11, 0) == useful.GeneralizedTime('2017071100').asDateTime
 
 
 class UTCTimeTestCase(unittest.TestCase):
 
-
     def testFromDateTime(self):
-        assert useful.UTCTime.fromDateTime(datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC)) == '20170711000102.3Z'
+        assert useful.UTCTime.fromDateTime(datetime.datetime(2017, 7, 11, 0, 1, 2, tzinfo=UTC)) == '170711000102Z'
 
-    def testToDateTime(self):
-        assert datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC) == useful.UTCTime('20170711000102.3Z').asDateTime
+    def testToDateTime0(self):
+        assert datetime.datetime(2017, 7, 11, 0, 1, 2) == useful.UTCTime('170711000102').asDateTime
+
+    def testToDateTime1(self):
+        assert datetime.datetime(2017, 7, 11, 0, 1, 2, tzinfo=UTC) == useful.UTCTime('170711000102Z').asDateTime
+
+    def testToDateTime2(self):
+        assert datetime.datetime(2017, 7, 11, 0, 1, 2, tzinfo=UTC) == useful.UTCTime('170711000102+0000').asDateTime
+
+    def testToDateTime3(self):
+        assert datetime.datetime(2017, 7, 11, 0, 1, 2, tzinfo=UTC2) == useful.UTCTime('170711000102+0200').asDateTime
+
+    def testToDateTime4(self):
+        assert datetime.datetime(2017, 7, 11, 0, 1) == useful.UTCTime('1707110001').asDateTime
+
+    def testToDateTime5(self):
+        assert datetime.datetime(2017, 7, 11, 0) == useful.UTCTime('17071100').asDateTime
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/type/test_useful.py
+++ b/tests/type/test_useful.py
@@ -1,0 +1,61 @@
+#
+# This file is part of pyasn1 software.
+#
+# Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+# License: http://pyasn1.sf.net/license.html
+#
+import sys
+import datetime
+from pyasn1.type import useful
+from pyasn1.error import PyAsn1Error
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+
+class FixedOffset(datetime.tzinfo):
+
+    def __init__(self, offset, name):
+        self.__offset = datetime.timedelta(minutes=offset)
+        self.__name = name
+
+    def utcoffset(self, dt):
+        return self.__offset
+
+    def tzname(self, dt):
+        return self.__name
+
+    def dst(self, dt):
+        return datetime.timedelta(0)
+
+
+UTC = FixedOffset(0, 'UTC')
+
+
+class ObjectDescriptorTestCase(unittest.TestCase):
+    pass
+
+class GeneralizedTimeTestCase(unittest.TestCase):
+
+    def testFromDateTime(self):
+        assert useful.GeneralizedTime.fromDateTime(datetime.datetime(2017, 07, 11, 0, 1, 2, 3, tzinfo=UTC)) == '2017071100010203,4+0000'
+
+    def testToDateTime(self):
+        assert datetime.datetime(2017, 07, 11, 0, 1, 2, 3, tzinfo=UTC) == useful.GeneralizedTime('2017071100010203,4+0000')
+
+
+class UTCTimeTestCase(unittest.TestCase):
+
+    def testFromDateTime(self):
+        assert useful.UTCTime.fromDateTime(datetime.datetime(2017, 07, 11, 0, 1, 2, 3, tzinfo=UTC)) == '2017071100010203,4+0000'
+
+    def testToDateTime(self):
+        assert datetime.datetime(2017, 07, 11, 0, 1, 2, 3, tzinfo=UTC) == useful.UTCTime('2017071100010203,4+0000')
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/type/test_useful.py
+++ b/tests/type/test_useful.py
@@ -40,10 +40,10 @@ class ObjectDescriptorTestCase(unittest.TestCase):
 class GeneralizedTimeTestCase(unittest.TestCase):
 
     def testFromDateTime(self):
-        assert useful.GeneralizedTime.fromDateTime(datetime.datetime(2017, 07, 11, 0, 1, 2, 3, tzinfo=UTC)) == '2017071100010203,4+0000'
+        assert useful.GeneralizedTime.fromDateTime(datetime.datetime(2017, 07, 11, 0, 1, 2, 30000, tzinfo=UTC)) == '20170711000102.3Z'
 
     def testToDateTime(self):
-        assert datetime.datetime(2017, 07, 11, 0, 1, 2, 3, tzinfo=UTC) == useful.GeneralizedTime('2017071100010203,4+0000')
+        assert datetime.datetime(2017, 07, 11, 0, 1, 2, 30000, tzinfo=UTC) == useful.GeneralizedTime('20170711000102.3Z').asDateTime
 
 
 class UTCTimeTestCase(unittest.TestCase):


### PR DESCRIPTION
This PR introduces .asDateTime property and .toDateTime() method to GeneralizedTime and UTCTime classes. The goal is to ease ASN.1 time types <-> Python date time conversion.