### PR TITLE
NamedValues refactoring 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,9 @@ Revision 0.3.1, released XX-07-2017
 - Reduced the frequency of expensive isinstance() calls
 - Tag-related classes optimized, refactored into properties and
   documented.
-- The NamedValues implementation improved, refactored into properties
-  and documented.
+- The NamedValues implementation refactored to mimic Python dict, its use
+  in ASN.1 types refactored into properties and better documented.
+  WARNING: this change introduces a deviation from original API.
 - NamedType family of classes overhauled, optimized and
   documented.
 - Sequence/Set DER/CER/DER decoder optimized to skip the case of

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Revision 0.3.1, released XX-07-2017
 - Reduced the frequency of expensive isinstance() calls
 - Tag-related classes optimized, refactored into properties and
   documented.
+- The NamedValues implementation improved, refactored into properties
+  and documented.
 - NamedType family of classes overhauled, optimized and
   documented.
 - Sequence/Set DER/CER/DER decoder optimized to skip the case of

--- a/doc/source/docs/api-reference.rst
+++ b/doc/source/docs/api-reference.rst
@@ -16,6 +16,7 @@ ASN.1 types
    /docs/type/useful/contents
    /docs/type/tag/contents
    /docs/type/namedtype/contents
+   /docs/type/namedval/contents
 
 Transformation codecs
 ---------------------

--- a/doc/source/docs/type/namedval/contents.rst
+++ b/doc/source/docs/type/namedval/contents.rst
@@ -1,0 +1,13 @@
+
+Enumerating numbers
+-------------------
+
+Some ASN.1 types such as :py:class:`~pyasn1.type.univ.Integer`,
+:py:class:`~pyasn1.type.univ.Enumerated` and
+:py:class:`~pyasn1.type.univ.BitString` may enumerate their values
+with human-friendly labels.
+
+.. toctree::
+   :maxdepth: 2
+
+   /docs/type/namedval/namedval

--- a/doc/source/docs/type/namedval/namedval.rst
+++ b/doc/source/docs/type/namedval/namedval.rst
@@ -1,0 +1,11 @@
+
+.. |NamedValues| replace:: NamedValues
+
+|NamedValues|
+-------------
+
+The |NamedValues| class associates human-friendly names to a set of numbers
+or bits.
+
+.. autoclass:: pyasn1.type.namedval.NamedValues
+   :members:

--- a/pyasn1/type/namedval.py
+++ b/pyasn1/type/namedval.py
@@ -24,13 +24,13 @@ class NamedValues(object):
     Parameters
     ----------
 
-    Var-args of tuples:
-
-    name: :py:class:`str`
-        Value name
-
-    value: :py:class:`int`
-        A numerical value
+    \*namedValues: variable number of two-element :py:class:`tuple` 
+        
+        name: :py:class:`str`
+            Value name
+    
+        value: :py:class:`int`
+                A numerical value
     """
     def __init__(self, *namedValues):
         self.nameToValIdx = {}

--- a/pyasn1/type/namedval.py
+++ b/pyasn1/type/namedval.py
@@ -19,65 +19,108 @@ class NamedValues(object):
     names to otherwise numerical values.
 
     |NamedValues| objects are immutable and duck-type Python
-    :class:`dict` objects mapping ID to name and vice-versa.
+    :class:`dict` object mapping ID to name and vice-versa.
 
     Parameters
     ----------
 
-    \*namedValues: variable number of two-element :py:class:`tuple` 
+    \*args: variable number of two-element :py:class:`tuple` 
+    \*\*kwargs: keyword parameters of:
         
         name: :py:class:`str`
             Value name
     
         value: :py:class:`int`
                 A numerical value
+
+    Examples
+    --------
+
+    >>> nv = namedval.NamedValues('a', 'b', ('c', 0), d=1)
+    >>> nv
+    >>> {'c': 0, 'd': 1, 'a': 2, 'b': 3}
+    >>> nv[0]
+    'c'
+    >>> nv['a']
+    2
     """
-    def __init__(self, *namedValues):
-        self.nameToValIdx = {}
-        self.valToNameIdx = {}
-        self.namedValues = ()
-        automaticVal = 1
-        for namedValue in namedValues:
-            if isinstance(namedValue, tuple):
-                name, val = namedValue
+    def __init__(self, *args, **kwargs):
+        self.__names = {}
+        self.__numbers = {}
+
+        anonymousNames = []
+
+        for namedValue in args:
+            if isinstance(namedValue, (tuple, list)):
+                try:
+                    name, number = namedValue
+
+                except ValueError:
+                    raise error.PyAsn1Error('Not a proper attribute-value pair %r' % (namedValue,))
+
             else:
-                name = namedValue
-                val = automaticVal
-            if name in self.nameToValIdx:
+                anonymousNames.append(namedValue)
+                continue
+
+            if name in self.__names:
                 raise error.PyAsn1Error('Duplicate name %s' % (name,))
-            self.nameToValIdx[name] = val
-            if val in self.valToNameIdx:
-                raise error.PyAsn1Error('Duplicate value %s=%s' % (name, val))
-            self.valToNameIdx[val] = name
-            self.namedValues = self.namedValues + ((name, val),)
-            automaticVal += 1
+
+            if number in self.__numbers:
+                raise error.PyAsn1Error('Duplicate number  %s=%s' % (name, number))
+
+            self.__names[name] = number
+            self.__numbers[number] = name
+
+        for name, number in kwargs.items():
+            if name in self.__names:
+                raise error.PyAsn1Error('Duplicate name %s' % (name,))
+
+            if number in self.__numbers:
+                raise error.PyAsn1Error('Duplicate number  %s=%s' % (name, number))
+
+            self.__names[name] = number
+            self.__numbers[number] = name
+
+        if anonymousNames:
+
+            number = self.__numbers and max(self.__numbers) + 1 or 0
+
+            for name in anonymousNames:
+
+                if name in self.__names:
+                    raise error.PyAsn1Error('Duplicate name %s' % (name,))
+
+                self.__names[name] = number
+                self.__numbers[number] = name
+
+                number += 1
 
     def __repr__(self):
-        return '%s(%s)' % (self.__class__.__name__, ', '.join([repr(x) for x in self.namedValues]))
+        return '%s(%r)' % (self.__class__.__name__, self.items())
 
     def __str__(self):
-        return str(self.namedValues)
+        return str(self.items())
 
     def __eq__(self, other):
-        return tuple(self) == tuple(other)
+        return dict(self) == other
 
     def __ne__(self, other):
-        return tuple(self) != tuple(other)
+        return dict(self) != other
 
     def __lt__(self, other):
-        return tuple(self) < tuple(other)
+        return dict(self) < other
 
     def __le__(self, other):
-        return tuple(self) <= tuple(other)
+        return dict(self) <= other
 
     def __gt__(self, other):
-        return tuple(self) > tuple(other)
+        return dict(self) > other
 
     def __ge__(self, other):
-        return tuple(self) >= tuple(other)
+        return dict(self) >= other
 
     def __hash__(self):
-        return hash(tuple(self))
+        return hash(self.items())
 
     # descriptor protocol
 
@@ -99,37 +142,60 @@ class NamedValues(object):
     def __set__(self, instance, value):
         raise AttributeError('attribute is read-only')
 
+    # Python dict protocol (read-only)
+
+    def __getitem__(self, key):
+        try:
+            return self.__numbers[key]
+
+        except KeyError:
+            return self.__names[key]
+
+    def __len__(self):
+        return len(self.__names)
+
+    def __contains__(self, key):
+        return key in self.__names or key in self.__numbers
+
+    def __iter__(self):
+        return iter(self.__names)
+
+    def values(self):
+        return iter(self.__numbers)
+
+    def keys(self):
+        return iter(self.__names)
+
+    def items(self):
+        for name in self.__names:
+            yield name, self.__names[name]
+
+    # support merging
+
+    def __add__(self, namedValues):
+        return self.__class__(*tuple(self.items()) + tuple(namedValues.items()))
+
+    # XXX clone/subtype?
+
+    def clone(self, *args, **kwargs):
+        new = self.__class__(*args, **kwargs)
+        return self + new
+
+    # legacy protocol
+
     def getName(self, value):
-        if value in self.valToNameIdx:
-            return self.valToNameIdx[value]
+        if value in self.__numbers:
+            return self.__numbers[value]
 
     def getValue(self, name):
-        if name in self.nameToValIdx:
-            return self.nameToValIdx[name]
+        if name in self.__names:
+            return self.__names[name]
 
     def getValues(self, *names):
         try:
-            return [self.nameToValIdx[name] for name in names]
+            return [self.__names[name] for name in names]
 
         except KeyError:
             raise error.PyAsn1Error(
-                'Unknown bit identifier(s): %s' % (set(names).difference(self.nameToValIdx),)
+                'Unknown bit identifier(s): %s' % (set(names).difference(self.__names),)
             )
-
-    # TODO support by-name subscription
-    def __getitem__(self, i):
-        return self.namedValues[i]
-
-    def __len__(self):
-        return len(self.namedValues)
-
-    def __add__(self, namedValues):
-        return self.__class__(*self.namedValues + namedValues)
-
-    def __radd__(self, namedValues):
-        return self.__class__(*namedValues + tuple(self))
-
-    def clone(self, *namedValues):
-        return self.__class__(*tuple(self) + namedValues)
-
-# XXX clone/subtype?

--- a/pyasn1/type/namedval.py
+++ b/pyasn1/type/namedval.py
@@ -12,6 +12,26 @@ __all__ = ['NamedValues']
 
 
 class NamedValues(object):
+    """Create named values object.
+
+    The |NamedValues| object represents a collection of string names
+    associated with numeric IDs. These objects are used for giving
+    names to otherwise numerical values.
+
+    |NamedValues| objects are immutable and duck-type Python
+    :class:`dict` objects mapping ID to name and vice-versa.
+
+    Parameters
+    ----------
+
+    Var-args of tuples:
+
+    name: :py:class:`str`
+        Value name
+
+    value: :py:class:`int`
+        A numerical value
+    """
     def __init__(self, *namedValues):
         self.nameToValIdx = {}
         self.valToNameIdx = {}
@@ -58,6 +78,26 @@ class NamedValues(object):
 
     def __hash__(self):
         return hash(tuple(self))
+
+    # descriptor protocol
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
+        # This is a bit of hack: look up instance attribute first,
+        # then try class attribute if instance attribute with that
+        # name is not available.
+        # The rationale is to have `.subtypeSpec`/`.sizeSpec` readable-writeable
+        # as a class attribute and read-only as instance attribute.
+        try:
+            return instance._namedValues
+
+        except AttributeError:
+            return self
+
+    def __set__(self, instance, value):
+        raise AttributeError('attribute is read-only')
 
     def getName(self, value):
         if value in self.valToNameIdx:

--- a/tests/type/test_namedval.py
+++ b/tests/type/test_namedval.py
@@ -18,12 +18,34 @@ class NamedValuesCaseBase(unittest.TestCase):
     def setUp(self):
         self.e = namedval.NamedValues(('off', 0), ('on', 1))
 
-    def testIter(self):
-        off, on = self.e
-        assert off == ('off', 0) or on == ('on', 1), 'unpack fails'
+    def testDict(self):
+        assert set(self.e.items()) == set([('off', 0), ('on', 1)])
+        assert set(self.e.keys()) == set(['off', 'on'])
+        assert set(self.e) == set(['off', 'on'])
+        assert set(self.e.values()) == set([0, 1])
+        assert 'on' in self.e and 'off' in self.e and 'xxx' not in self.e
+        assert 0 in self.e and 1 in self.e and 2 not in self.e
 
-    def testRepr(self):
-        assert eval(repr(self.e), {'NamedValues': namedval.NamedValues}) == self.e, 'repr() fails'
+    def testInit(self):
+        assert namedval.NamedValues(off=0, on=1) == {'off': 0, 'on': 1}
+        assert namedval.NamedValues('off', 'on') == {'off': 0, 'on': 1}
+        assert namedval.NamedValues(('c', 0)) == {'c': 0}
+        assert namedval.NamedValues('a', 'b', ('c', 0), d=1) == {'c': 0, 'd': 1, 'a': 2, 'b': 3}
+
+    def testLen(self):
+        assert len(self.e) == 2
+        assert len(namedval.NamedValues()) == 0
+
+    def testAdd(self):
+        assert namedval.NamedValues(off=0) + namedval.NamedValues(on=1) == {'off': 0, 'on': 1}
+
+    def testClone(self):
+        assert namedval.NamedValues(off=0).clone(('on', 1)) == {'off': 0, 'on': 1}
+        assert namedval.NamedValues(off=0).clone(on=1) == {'off': 0, 'on': 1}
+
+    def testStrRepr(self):
+        assert str(self.e)
+        assert repr(self.e)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])


### PR DESCRIPTION
This PR refactors the NamedValues class to mock Python dict and makes NamedValues instances accessible as a property of ASN.1 type.