### PR TITLE
.componentType as a property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,8 +17,9 @@ Revision 0.3.1, released XX-07-2017
 - The NamedValues implementation refactored to mimic Python dict, its use
   in ASN.1 types refactored into properties and better documented.
   WARNING: this change introduces a deviation from original API.
-- NamedType family of classes overhauled, optimized and
-  documented.
+- NamedType family of classes overhauled, optimized and documented.
+- The `componentType` attribute of constructed ASN.1 types turned
+  into Python property.
 - Sequence/Set DER/CER/DER decoder optimized to skip the case of
   reordered components handling when not necessary.
 - Tags and constraints-related getter methods refactored into descriptors/properties.

--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -533,11 +533,10 @@ class SetDecoder(SequenceAndSetDecoderBase):
         return asn1Object.componentTagMap
 
     def _getComponentPositionByType(self, asn1Object, tagSet, idx):
-        nextIdx = asn1Object.getComponentPositionByType(tagSet)
-        if nextIdx is None:
-            return idx
+        if asn1Object.componentType:
+            return asn1Object.componentType.getPositionByType(tagSet)
         else:
-            return nextIdx
+            return idx
 
 
 class SetOfDecoder(SequenceOfDecoder):

--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -530,7 +530,7 @@ class SetDecoder(SequenceAndSetDecoderBase):
     orderedComponents = False
 
     def _getComponentTagMap(self, asn1Object, idx):
-        return asn1Object.componentTagMap
+        return asn1Object.componentType.tagMapUnique
 
     def _getComponentPositionByType(self, asn1Object, tagSet, idx):
         if asn1Object.componentType:
@@ -576,14 +576,14 @@ class ChoiceDecoder(AbstractConstructedDecoder):
         if substrateFun:
             return substrateFun(asn1Object, substrate, length)
         if asn1Object.tagSet == tagSet:  # explicitly tagged Choice
-            component, substrate = decodeFun(substrate, asn1Object.componentTagMap)
+            component, substrate = decodeFun(substrate, asn1Object.componentType.tagMapUnique)
             # eat up EOO marker
             eooMarker, substrate = decodeFun(substrate, allowEoo=True)
             if eooMarker is not eoo.endOfOctets:
                 raise error.PyAsn1Error('No EOO seen before substrate ends')
         else:
             component, substrate = decodeFun(
-                substrate, asn1Object.componentTagMap, tagSet, length, state
+                substrate, asn1Object.componentType.tagMapUnique, tagSet, length, state
             )
         effectiveTagSet = component.effectiveTagSet
         asn1Object.setComponentByType(

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -597,10 +597,6 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
     def setDefaultComponents(self):
         pass
 
-    @property
-    def componentTagMap(self):
-        raise error.PyAsn1Error('Method not implemented')
-
     def __getitem__(self, idx):
         return self.getComponentByPosition(idx)
 
@@ -612,7 +608,3 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
 
     def clear(self):
         self._componentValues = []
-
-    # backward compatibility
-    def getComponentTagMap(self):
-        return self.componentTagMap

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -5,7 +5,7 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
-from pyasn1.type import constraint, tagmap, tag
+from pyasn1.type import constraint, tagmap, tag, unnamedtype
 from pyasn1 import error
 
 __all__ = ['Asn1Item', 'Asn1ItemBase', 'AbstractSimpleAsn1Item', 'AbstractConstructedAsn1Item']
@@ -436,13 +436,17 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
     #: otherwise subtype relation is only enforced
     strictConstraints = False
 
+    componentType = None
+    sizeSpec = None
+
     def __init__(self, componentType=None, tagSet=None,
                  subtypeSpec=None, sizeSpec=None):
         Asn1ItemBase.__init__(self, tagSet, subtypeSpec)
         if componentType is None:
-            self._componentType = self.componentType
-        else:
-            self._componentType = componentType
+            componentType = self.componentType
+        if componentType is None or isinstance(componentType, Asn1Item):
+            componentType = unnamedtype.UnnamedType(componentType)
+        self._componentType = componentType
         if sizeSpec is None:
             self._sizeSpec = self.sizeSpec
         else:

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -455,11 +455,11 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
 
     def __repr__(self):
         representation = []
-        if self._componentType is not self.componentType:
+        if self.componentType is not self.__class__.componentType:
             representation.append('componentType=%r' % (self._componentType,))
-        if self._tagSet is not self.__class__.tagSet:
+        if self.tagSet is not self.__class__.tagSet:
             representation.append('tagSet=%r' % (self._tagSet,))
-        if self._subtypeSpec is not self.subtypeSpec:
+        if self.subtypeSpec is not self.__class__.subtypeSpec:
             representation.append('subtypeSpec=%r' % (self._subtypeSpec,))
         representation = '%s(%s)' % (self.__class__.__name__, ', '.join(representation))
         if self._componentValues:

--- a/pyasn1/type/namedtype.py
+++ b/pyasn1/type/namedtype.py
@@ -166,6 +166,26 @@ class NamedTypes(object):
     def __len__(self):
         return self.__namedTypesLen
 
+    # descriptor protocol
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
+        # This is a bit of hack: look up instance attribute first,
+        # then try class attribute if instance attribute with that
+        # name is not available.
+        # The rationale is to have `.componentType` readable-writeable
+        # as a class attribute and read-only as instance attribute.
+        try:
+            return instance._componentType
+
+        except AttributeError:
+            return self
+
+    def __set__(self, instance, value):
+        raise AttributeError('attribute is read-only')
+
     # Python dict protocol
 
     def values(self):

--- a/pyasn1/type/namedtype.py
+++ b/pyasn1/type/namedtype.py
@@ -359,7 +359,7 @@ class NamedTypes(object):
             If given position is out of fields range
         """
         try:
-            return self.__ambigiousTypes[idx].getTagMap()
+            return self.__ambigiousTypes[idx].tagMap
 
         except KeyError:
             raise error.PyAsn1Error('Type position out of range')
@@ -422,39 +422,7 @@ class NamedTypes(object):
                     self.__minTagSet = tagSet
         return self.__minTagSet
 
-    def getTagMap(self, unique=False):
-        """Create a *TagMap* object from tags and types recursively.
-
-        Create a new :class:`~pyasn1.type.tagmap.TagMap` object by
-        combining tags from *TagMap* objects of children types and
-        associating them with their immediate child type.
-
-        Example
-        -------
-
-        .. code-block:: python
-
-            OuterType ::= CHOICE {
-                innerType INTEGER
-            }
-
-        Calling *.getTagMap()* on *OuterType* will yield a map like this:
-
-        .. code-block:: python
-
-            Integer.tagSet -> Choice
-
-        Parameters
-        ----------
-        unique: :py:class:`bool`
-            If `True`, duplicate *TagSet* objects occurring while building
-            new *TagMap* would cause error.
-
-        Returns
-        -------
-        : :class:`~pyasn1.type.tagmap.TagMap`
-            New *TagMap* holding *TagSet* object gathered from childen types.
-        """
+    def __getTagMap(self, unique):
         if unique not in self.__tagMap:
             presentTypes = {}
             skipTypes = {}
@@ -475,6 +443,62 @@ class NamedTypes(object):
             self.__tagMap[unique] = tagmap.TagMap(presentTypes, skipTypes, defaultType)
 
         return self.__tagMap[unique]
+
+    @property
+    def tagMap(self):
+        """Return a *TagMap* object from tags and types recursively.
+
+        Return a :class:`~pyasn1.type.tagmap.TagMap` object by
+        combining tags from *TagMap* objects of children types and
+        associating them with their immediate child type.
+
+        Example
+        -------
+
+        .. code-block:: python
+
+           OuterType ::= CHOICE {
+               innerType INTEGER
+           }
+
+        Calling *.tagMap* on *OuterType* will yield a map like this:
+
+        .. code-block:: python
+
+           Integer.tagSet -> Choice
+        """
+        return self.__getTagMap(unique=False)
+
+    @property
+    def tagMapUnique(self):
+        """Return a *TagMap* object from unique tags and types recursively.
+
+        Return a :class:`~pyasn1.type.tagmap.TagMap` object by
+        combining tags from *TagMap* objects of children types and
+        associating them with their immediate child type.
+
+        Example
+        -------
+
+        .. code-block:: python
+
+           OuterType ::= CHOICE {
+               innerType INTEGER
+           }
+
+        Calling *.tagMapUnique* on *OuterType* will yield a map like this:
+
+        .. code-block:: python
+
+           Integer.tagSet -> Choice
+
+        Note
+        ----
+
+        Duplicate *TagSet* objects found in the tree of children
+        types would cause error.
+        """
+        return self.__getTagMap(unique=True)
 
     @property
     def hasOptionalOrDefault(self):

--- a/pyasn1/type/namedval.py
+++ b/pyasn1/type/namedval.py
@@ -131,7 +131,7 @@ class NamedValues(object):
         # This is a bit of hack: look up instance attribute first,
         # then try class attribute if instance attribute with that
         # name is not available.
-        # The rationale is to have `.subtypeSpec`/`.sizeSpec` readable-writeable
+        # The rationale is to have `.namedValues` readable-writeable
         # as a class attribute and read-only as instance attribute.
         try:
             return instance._namedValues

--- a/pyasn1/type/tagmap.py
+++ b/pyasn1/type/tagmap.py
@@ -16,7 +16,7 @@ class TagMap(object):
 
     *TagMap* objects are immutable and duck-type read-only Python
     :class:`dict` objects holding *TagSet* objects as keys and ASN.1
-     type objects as values.
+    type objects as values.
 
     Parameters
     ----------

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -6,7 +6,7 @@
 #
 import sys
 import math
-from pyasn1.type import base, tag, constraint, namedtype, namedval, tagmap
+from pyasn1.type import base, tag, constraint, namedtype, unnamedtype, namedval, tagmap
 from pyasn1.codec.ber import eoo
 from pyasn1.compat import octets, integer, binary
 from pyasn1 import error
@@ -1823,6 +1823,8 @@ class SequenceOfAndSetOfBase(base.AbstractConstructedAsn1Item):
         Object representing collection size constraint
      """
 
+    componentType = unnamedtype.UnnamedType()
+
     # Python list protocol
 
     def clear(self):
@@ -1925,7 +1927,7 @@ class SequenceOfAndSetOfBase(base.AbstractConstructedAsn1Item):
         IndexError:
             When idx > len(self)
         """
-        componentType = self._componentType
+        componentType = self._componentType.asn1Object
 
         try:
             currentValue = self._componentValues[idx]
@@ -1972,8 +1974,8 @@ class SequenceOfAndSetOfBase(base.AbstractConstructedAsn1Item):
 
     @property
     def componentTagMap(self):
-        if self._componentType is not None:
-            return self._componentType.tagMap
+        if self._componentType.asn1Object is not None:
+            return self._componentType.asn1Object.tagMap
 
     def prettyPrint(self, scope=0):
         scope += 1
@@ -1989,9 +1991,9 @@ class SequenceOfAndSetOfBase(base.AbstractConstructedAsn1Item):
     def prettyPrintType(self, scope=0):
         scope += 1
         representation = '%s -> %s {\n' % (self.tagSet, self.__class__.__name__)
-        if self._componentType is not None:
+        if self._componentType.asn1Object is not None:
             representation += ' ' * scope
-            representation += self._componentType.prettyPrintType(scope)
+            representation += self._componentType.asn1Object.prettyPrintType(scope)
         return representation + '\n' + ' ' * (scope - 1) + '}'
 
 
@@ -2034,7 +2036,7 @@ class SequenceOf(SequenceOfAndSetOfBase):
 
     #: Default :py:class:`~pyasn1.type.base.PyAsn1Item` derivative
     #: object representing ASN.1 type allowed within |ASN.1| type
-    componentType = None
+    componentType = unnamedtype.UnnamedType()
 
     #: Set (class attribute) or return (class or instance attribute) a
     #: :py:class:`~pyasn1.type.constraint.ConstraintsIntersection` object
@@ -2061,7 +2063,7 @@ class SetOf(SequenceOfAndSetOfBase):
 
     #: Default :py:class:`~pyasn1.type.base.PyAsn1Item` derivative
     #: object representing ASN.1 type allowed within |ASN.1| type
-    componentType = None
+    componentType = unnamedtype.UnnamedType()
 
     #: Set (class attribute) or return (class or instance attribute) a
     #: :py:class:`~pyasn1.type.constraint.ConstraintsIntersection` object

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -2555,10 +2555,6 @@ class Set(SequenceAndSetBase):
         if self._componentType:
             return self._componentType.getTagMap(True)
 
-    def getComponentPositionByType(self, tagSet):
-        if self._componentType:
-            return self._componentType.getPositionByType(tagSet)
-
 
 class Choice(Set):
     __doc__ = Set.__doc__

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -2553,7 +2553,7 @@ class Set(SequenceAndSetBase):
     @property
     def componentTagMap(self):
         if self._componentType:
-            return self._componentType.getTagMap(True)
+            return self._componentType.tagMapUnique
 
 
 class Choice(Set):
@@ -2742,7 +2742,7 @@ class Choice(Set):
         if self._tagSet:
             return Set.tagMap.fget(self)
         else:
-            return Set.componentTagMap.fget(self)
+            return self.componentType.tagMapUnique
 
     def getComponent(self, innerFlag=0):
         """Return currently assigned component of the |ASN.1| object.
@@ -2799,7 +2799,6 @@ class Choice(Set):
             return False
 
         return self._componentValues[self._currentIdx].isValue
-
 
     # compatibility stubs
 

--- a/pyasn1/type/unnamedtype.py
+++ b/pyasn1/type/unnamedtype.py
@@ -19,6 +19,9 @@ class UnnamedType(object):
     def __init__(self, asn1Object=None):
         self.__asn1Object = asn1Object
 
+    def __repr__(self):
+        return '%s(%r)' % (self.__class__.__name__, self.__asn1Object)
+
     # descriptor protocol
 
     def __get__(self, instance, owner):

--- a/pyasn1/type/unnamedtype.py
+++ b/pyasn1/type/unnamedtype.py
@@ -1,0 +1,44 @@
+#
+# This file is part of pyasn1 software.
+#
+# Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+# License: http://pyasn1.sf.net/license.html
+#
+
+
+class UnnamedType(object):
+    """Create a container holding a single ASN.1 type.
+
+    The UnnamedType object represents a single, unnamed ASN.1 type
+    for the field definition of constructed ASN.1 types.
+
+    Parameters
+    ----------
+    *asn1Object: :class:`~pyasn1.type.base.Asn1Item`
+    """
+    def __init__(self, asn1Object=None):
+        self.__asn1Object = asn1Object
+
+    # descriptor protocol
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
+        # This is a bit of hack: look up instance attribute first,
+        # then try class attribute if instance attribute with that
+        # name is not available.
+        # The rationale is to have `.componentType` readable-writeable
+        # as a class attribute and read-only as instance attribute.
+        try:
+            return instance._componentType
+
+        except AttributeError:
+            return self
+
+    def __set__(self, instance, value):
+        raise AttributeError('attribute is read-only')
+
+    @property
+    def asn1Object(self):
+        return self.__asn1Object

--- a/tests/type/test_namedtype.py
+++ b/tests/type/test_namedtype.py
@@ -75,24 +75,24 @@ class NamedTypesCaseBase(unittest.TestCase):
         }
 
     def testGetTagMap(self):
-        assert self.e.getTagMap().presentTypes == {
+        assert self.e.tagMap.presentTypes == {
             univ.OctetString.tagSet: univ.OctetString(''),
             univ.Integer.tagSet: univ.Integer(0)
         }
 
     def testStrTagMap(self):
-        assert 'TagMap' in str(self.e.getTagMap())
-        assert 'OctetString' in str(self.e.getTagMap())
-        assert 'Integer' in str(self.e.getTagMap())
+        assert 'TagMap' in str(self.e.tagMap)
+        assert 'OctetString' in str(self.e.tagMap)
+        assert 'Integer' in str(self.e.tagMap)
 
     def testReprTagMap(self):
-        assert 'TagMap' in repr(self.e.getTagMap())
-        assert 'OctetString' in repr(self.e.getTagMap())
-        assert 'Integer' in repr(self.e.getTagMap())
+        assert 'TagMap' in repr(self.e.tagMap)
+        assert 'OctetString' in repr(self.e.tagMap)
+        assert 'Integer' in repr(self.e.tagMap)
 
     def testGetTagMapWithDups(self):
         try:
-            self.e.getTagMap(True)
+            self.e.tagMapUnique
         except PyAsn1Error:
             pass
         else:

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -6,7 +6,7 @@
 #
 import sys
 import math
-from pyasn1.type import univ, tag, constraint, namedtype, namedval, error
+from pyasn1.type import univ, tag, constraint, namedtype, unnamedtype, namedval, error
 from pyasn1.compat.octets import str2octs, ints2octs, octs2ints
 from pyasn1.error import PyAsn1Error
 
@@ -730,7 +730,9 @@ class SequenceOf(unittest.TestCase):
 
     def testRepr(self):
         assert eval(repr(self.s1.clone().setComponents('a', 'b')),
-                    {'SequenceOf': univ.SequenceOf, 'OctetString': univ.OctetString}) == self.s1.clone().setComponents(
+                    {'UnnamedType': unnamedtype.UnnamedType,
+                     'SequenceOf': univ.SequenceOf,
+                     'OctetString': univ.OctetString}) == self.s1.clone().setComponents(
             'a', 'b'), 'repr() fails'
 
     def testTag(self):
@@ -1080,7 +1082,7 @@ class Set(unittest.TestCase):
         }
 
     def testGetPositionByType(self):
-        assert self.s1.getComponentPositionByType(univ.Null().tagSet) == 1
+        assert self.s1.componentType.getPositionByType(univ.Null().tagSet) == 1
 
     def testSetToDefault(self):
         self.s1.setComponentByName('name', univ.noValue)
@@ -1092,14 +1094,18 @@ class Set(unittest.TestCase):
 
 class Choice(unittest.TestCase):
     def setUp(self):
-        innerComp = univ.Choice(componentType=namedtype.NamedTypes(
-            namedtype.NamedType('count', univ.Integer()),
-            namedtype.NamedType('flag', univ.Boolean())
-        ))
-        self.s1 = univ.Choice(componentType=namedtype.NamedTypes(
-            namedtype.NamedType('name', univ.OctetString()),
-            namedtype.NamedType('sex', innerComp)
-        ))
+        innerComp = univ.Choice(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('count', univ.Integer()),
+                namedtype.NamedType('flag', univ.Boolean())
+            )
+        )
+        self.s1 = univ.Choice(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString()),
+                namedtype.NamedType('sex', innerComp)
+            )
+        )
 
     def testTag(self):
         assert self.s1.tagSet == tag.TagSet(), 'wrong tagSet'

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -821,7 +821,7 @@ class SequenceOf(unittest.TestCase):
             assert 0, 'size spec fails'
 
     def testGetComponentTagMap(self):
-        assert self.s1.getComponentTagMap().presentTypes == {
+        assert self.s1.componentType.asn1Object.tagMap.presentTypes == {
             univ.OctetString.tagSet: univ.OctetString('')
         }
 
@@ -1075,7 +1075,7 @@ class Set(unittest.TestCase):
         }
 
     def testGetComponentTagMap(self):
-        assert self.s1.getComponentTagMap().presentTypes == {
+        assert self.s1.componentType.tagMapUnique.presentTypes == {
             univ.OctetString.tagSet: univ.OctetString(''),
             univ.Null.tagSet: univ.Null(''),
             univ.Integer.tagSet: univ.Integer(34)


### PR DESCRIPTION
This PR refactors `.componentType` attribute of constructed ASN.1 types into a read-only property (like all other ASN.1-related attributes).

By way of doing this, the `SetOf/SequenceOf.componentType` becomes a container holding single ASN.1 type denoting the only field of the type.