### PR TITLE
.componentType as a property follow up

### DIFF
--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -372,7 +372,7 @@ class SequenceAndSetDecoderBase(AbstractConstructedDecoder):
         if substrateFun:
             return substrateFun(asn1Object, substrate, length)
 
-        namedTypes = asn1Object.getComponentType()
+        namedTypes = asn1Object.componentType
 
         if not self.orderedComponents or not namedTypes or namedTypes.hasOptionalOrDefault:
             seenIndices = set()
@@ -414,7 +414,7 @@ class SequenceAndSetDecoderBase(AbstractConstructedDecoder):
         if substrateFun:
             return substrateFun(asn1Object, substrate, length)
 
-        namedTypes = asn1Object.getComponentType()
+        namedTypes = asn1Object.componentType
 
         if not namedTypes or namedTypes.hasOptionalOrDefault:
             seenIndices = set()
@@ -487,7 +487,7 @@ class SequenceOfDecoder(AbstractConstructedDecoder):
         asn1Object = self._createComponent(asn1Spec, tagSet)
         if substrateFun:
             return substrateFun(asn1Object, substrate, length)
-        asn1Spec = asn1Object.getComponentType()
+        asn1Spec = asn1Object.componentType.asn1Object
         idx = 0
         while head:
             component, head = decodeFun(head, asn1Spec)
@@ -505,7 +505,7 @@ class SequenceOfDecoder(AbstractConstructedDecoder):
         asn1Object = self._createComponent(asn1Spec, tagSet)
         if substrateFun:
             return substrateFun(asn1Object, substrate, length)
-        asn1Spec = asn1Object.getComponentType()
+        asn1Spec = asn1Object.componentType.asn1Object
         idx = 0
         while substrate:
             component, substrate = decodeFun(substrate, asn1Spec, allowEoo=True)

--- a/pyasn1/codec/ber/encoder.py
+++ b/pyasn1/codec/ber/encoder.py
@@ -339,7 +339,7 @@ class RealEncoder(AbstractItemEncoder):
 class SequenceEncoder(AbstractItemEncoder):
     def encodeValue(self, encodeFun, value, defMode, maxChunkSize):
         value.verifySizeSpec()
-        namedTypes = value.getComponentType()
+        namedTypes = value.componentType
         substrate = null
         idx = len(value)
         while idx > 0:

--- a/pyasn1/codec/cer/encoder.py
+++ b/pyasn1/codec/cer/encoder.py
@@ -98,7 +98,7 @@ class SetOfEncoder(encoder.SequenceOfEncoder):
         # from Set if they have the same tags&constraints?
         if isinstance(client, univ.SequenceAndSetBase):
             # Set
-            namedTypes = client.getComponentType()
+            namedTypes = client.componentType
             comps = []
             while idx > 0:
                 idx -= 1

--- a/pyasn1/codec/native/decoder.py
+++ b/pyasn1/codec/native/decoder.py
@@ -24,7 +24,7 @@ class SequenceOrSetDecoder(object):
     def __call__(self, pyObject, asn1Spec, decoderFunc):
         asn1Value = asn1Spec.clone()
 
-        componentsTypes = asn1Spec.getComponentType()
+        componentsTypes = asn1Spec.componentType
 
         for field in asn1Value:
             if field in pyObject:
@@ -38,7 +38,7 @@ class SequenceOfOrSetOfDecoder(object):
         asn1Value = asn1Spec.clone()
 
         for pyValue in pyObject:
-            asn1Value.append(decoderFunc(pyValue, asn1Spec.getComponentType()))
+            asn1Value.append(decoderFunc(pyValue, asn1Spec.componentType.asn1Object))
 
         return asn1Value
 
@@ -47,7 +47,7 @@ class ChoiceDecoder(object):
     def __call__(self, pyObject, asn1Spec, decoderFunc):
         asn1Value = asn1Spec.clone()
 
-        componentsTypes = asn1Spec.getComponentType()
+        componentsTypes = asn1Spec.componentType
 
         for field in pyObject:
             if field in componentsTypes:

--- a/pyasn1/codec/native/encoder.py
+++ b/pyasn1/codec/native/encoder.py
@@ -77,7 +77,7 @@ class SetEncoder(AbstractItemEncoder):
     protoDict = dict
     def encode(self, encodeFun, value):
         value.verifySizeSpec()
-        namedTypes = value.getComponentType()
+        namedTypes = value.componentType
         substrate = self.protoDict()
         for idx, (key, subValue) in enumerate(value.items()):
             if namedTypes[idx].isOptional and not value[idx].isValue:

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -436,7 +436,7 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
     #: otherwise subtype relation is only enforced
     strictConstraints = False
 
-    componentType = None
+    componentType = unnamedtype.UnnamedType()
     sizeSpec = None
 
     def __init__(self, componentType=None, tagSet=None,
@@ -444,8 +444,6 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
         Asn1ItemBase.__init__(self, tagSet, subtypeSpec)
         if componentType is None:
             componentType = self.componentType
-        if componentType is None or isinstance(componentType, Asn1Item):
-            componentType = unnamedtype.UnnamedType(componentType)
         self._componentType = componentType
         if sizeSpec is None:
             self._sizeSpec = self.sizeSpec
@@ -590,13 +588,6 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
             self[k] = kwargs[k]
         return self
 
-    def getComponentType(self):
-        return self._componentType
-
-    # backward compatibility -- no-op
-    def setDefaultComponents(self):
-        pass
-
     def __getitem__(self, idx):
         return self.getComponentByPosition(idx)
 
@@ -608,3 +599,11 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
 
     def clear(self):
         self._componentValues = []
+
+    # backward compatibility
+
+    def setDefaultComponents(self):
+        pass
+
+    def getComponentType(self):
+        return self.componentType

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -1803,13 +1803,13 @@ class Enumerated(Integer):
 
 # "Structured" ASN.1 types
 
-class ComponentWrappingMeta(type):
+class MetaSingleComponentWrapping(type):
 
     def __init__(cls, name, bases, dct):
         if not isinstance(cls.componentType, unnamedtype.UnnamedType):
             cls.componentType = unnamedtype.UnnamedType(cls.componentType)
 
-        super(ComponentWrappingMeta, cls).__init__(name, bases, dct)
+        super(MetaSingleComponentWrapping, cls).__init__(name, bases, dct)
 
     def __call__(cls, *args, **kwargs):
         try:
@@ -1823,18 +1823,7 @@ class ComponentWrappingMeta(type):
         return type.__call__(cls, *args, **kwargs)
 
 
-if sys.version_info[0] < 3:
-    class ComponentWrapper(base.AbstractConstructedAsn1Item):
-        __metaclass__ = ComponentWrappingMeta
-
-else:
-    class ComponentWrapper(base.AbstractConstructedAsn1Item):
-# TODO: make this portable
-#                           metaclass=ComponentWrappingMeta):
-        pass
-
-
-class SequenceOfAndSetOfBase(ComponentWrapper):
+class SequenceOfAndSetOfBase(base.AbstractConstructedAsn1Item):
     """Create |ASN.1| type.
 
     |ASN.1| objects are mutable and duck-type Python :class:`list` objects.
@@ -2053,6 +2042,15 @@ class SequenceOfAndSetOfBase(ComponentWrapper):
                 return False
 
         return True
+
+# Portable way to involve a metaclass
+__class_body = vars(SequenceOfAndSetOfBase).copy()
+__class_body.pop('__dict__', None)
+__class_body.pop('__weakref__', None)
+
+SequenceOfAndSetOfBase = MetaSingleComponentWrapping(
+    SequenceOfAndSetOfBase.__name__, SequenceOfAndSetOfBase.__bases__, __class_body
+)
 
 
 class SequenceOf(SequenceOfAndSetOfBase):


### PR DESCRIPTION
This PR is a follow up to https://github.com/etingof/pyasn1/pull/46 which turned out to be incomplete and not fully functional.

This PR hopefully fixes that, specifically by reliably wrapping SequenceOf/SetOf.componentType into a container at the class creation phase.