### PR TITLE
Python 2.5-2.5/3.0-3.1 fixes

### DIFF
--- a/pyasn1/compat/binary.py
+++ b/pyasn1/compat/binary.py
@@ -10,6 +10,14 @@ if version_info[0:2] < (2, 6):
     def bin(value):
         bitstring = []
 
+        if value > 0:
+            prefix = '0b'
+        elif value < 0:
+            prefix = '-0b'
+            value = abs(value)
+        else:
+            prefix = '0b0'
+
         while value:
             if value & 1 == 1:
                 bitstring.append('1')
@@ -20,6 +28,6 @@ if version_info[0:2] < (2, 6):
 
         bitstring.reverse()
 
-        return '0b' + ''.join(bitstring)
+        return prefix + ''.join(bitstring)
 else:
     bin = bin

--- a/pyasn1/compat/calling.py
+++ b/pyasn1/compat/calling.py
@@ -1,0 +1,19 @@
+#
+# This file is part of pyasn1 software.
+#
+# Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+# License: http://pyasn1.sf.net/license.html
+#
+from sys import version_info
+
+__all__ = ['callable']
+
+
+if (2, 7) < version_info[:2] < (3, 2):
+    import collections
+
+    callable = lambda x: isinstance(x, collections.Callable)
+
+else:
+
+    callable = callable

--- a/pyasn1/compat/dateandtime.py
+++ b/pyasn1/compat/dateandtime.py
@@ -1,0 +1,22 @@
+#
+# This file is part of pyasn1 software.
+#
+# Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+# License: http://pyasn1.sf.net/license.html
+#
+from sys import version_info
+from datetime import datetime
+import time
+
+__all__ = ['strptime']
+
+
+if version_info[:2] <= (2, 4):
+
+    def strptime(text, dateFormat):
+        return datetime(*(time.strptime(text, dateFormat)[0:6]))
+
+else:
+
+    def strptime(text, dateFormat):
+        return datetime.strptime(text, dateFormat)

--- a/pyasn1/compat/integer.py
+++ b/pyasn1/compat/integer.py
@@ -9,7 +9,7 @@ try:
     import platform
     implementation = platform.python_implementation()
 
-except ImportError:
+except (ImportError, AttributeError):
     implementation = 'CPython'
 
 if sys.version_info[0:2] < (3, 2):

--- a/pyasn1/compat/string.py
+++ b/pyasn1/compat/string.py
@@ -1,0 +1,26 @@
+#
+# This file is part of pyasn1 software.
+#
+# Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+# License: http://pyasn1.sf.net/license.html
+#
+from sys import version_info
+
+if version_info[:2] <= (2, 5):
+
+    def partition(string, sep):
+        try:
+            a, c = string.split(sep, 1)
+
+        except ValueError:
+            a, b, c = string, '', ''
+
+        else:
+            b = sep
+
+        return a, b, c
+
+else:
+
+    def partition(string, sep):
+        return string.partition(sep)

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -6,6 +6,7 @@
 #
 import sys
 from pyasn1.type import constraint, tagmap, tag, unnamedtype
+from pyasn1.compat import calling
 from pyasn1 import error
 
 __all__ = ['Asn1Item', 'Asn1ItemBase', 'AbstractSimpleAsn1Item', 'AbstractConstructedAsn1Item']
@@ -162,7 +163,10 @@ class NoValue(object):
             op_names = [name
                         for typ in (str, int, list, dict)
                         for name in dir(typ)
-                        if name not in cls.skipMethods and name.startswith('__') and name.endswith('__') and callable(getattr(typ, name))]
+                        if (name not in cls.skipMethods and
+                            name.startswith('__') and
+                            name.endswith('__') and
+                            calling.callable(getattr(typ, name)))]
 
             for name in set(op_names):
                 setattr(cls, name, getPlug(name))

--- a/pyasn1/type/useful.py
+++ b/pyasn1/type/useful.py
@@ -6,6 +6,7 @@
 #
 import datetime
 from pyasn1.type import univ, char, tag
+from pyasn1.compat import string, dateandtime
 from pyasn1 import error
 
 __all__ = ['ObjectDescriptor', 'GeneralizedTime', 'UTCTime']
@@ -57,16 +58,16 @@ class TimeMixIn(object):
         :
             new instance of :py:class:`datetime.datetime` object            
         """
-        string = str(self)
-        if string.endswith('Z'):
+        text = str(self)
+        if text.endswith('Z'):
             tzinfo = TimeMixIn.UTC
-            string = string[:-1]
+            text = text[:-1]
 
-        elif '-' in string or '+' in string:
-            if '+' in string:
-                string, plusminus, tz = string.partition('+')
+        elif '-' in text or '+' in text:
+            if '+' in text:
+                text, plusminus, tz = string.partition(text, '+')
             else:
-                string, plusminus, tz = string.partition('-')
+                text, plusminus, tz = string.partition(text, '-')
 
             if self._shortTZ and len(tz) == 2:
                 tz += '00'
@@ -87,11 +88,11 @@ class TimeMixIn(object):
         else:
             tzinfo = None
 
-        if '.' in string or ',' in string:
-            if '.' in string:
-                string, _, ms = string.partition('.')
+        if '.' in text or ',' in text:
+            if '.' in text:
+                text, _, ms = string.partition(text, '.')
             else:
-                string, _, ms = string.partition(',')
+                text, _, ms = string.partition(text, ',')
 
             try:
                 ms = int(ms) * 10000
@@ -102,13 +103,13 @@ class TimeMixIn(object):
         else:
             ms = 0
 
-        if self._optionalMinutes and len(string) - self._yearsDigits == 6:
-            string += '0000'
-        elif len(string) - self._yearsDigits == 8:
-            string += '00'
+        if self._optionalMinutes and len(text) - self._yearsDigits == 6:
+            text += '0000'
+        elif len(text) - self._yearsDigits == 8:
+            text += '00'
 
         try:
-            dt = datetime.datetime.strptime(string, self._yearsDigits == 4 and '%Y%m%d%H%M%S' or '%y%m%d%H%M%S')
+            dt = dateandtime.strptime(text, self._yearsDigits == 4 and '%Y%m%d%H%M%S' or '%y%m%d%H%M%S')
 
         except ValueError:
             raise error.PyAsn1Error('malformed datetime format %s' % self)
@@ -130,21 +131,21 @@ class TimeMixIn(object):
         :
             new instance of |ASN.1| value
         """
-        string = dt.strftime(cls._yearsDigits == 4 and '%Y%m%d%H%M%S' or '%y%m%d%H%M%S')
+        text = dt.strftime(cls._yearsDigits == 4 and '%Y%m%d%H%M%S' or '%y%m%d%H%M%S')
         if cls._hasSubsecond:
-            string += '.%d' % (dt.microsecond // 10000)
+            text += '.%d' % (dt.microsecond // 10000)
 
         if dt.utcoffset():
             seconds = dt.utcoffset().seconds
             if seconds < 0:
-                string += '-'
+                text += '-'
             else:
-                string += '+'
-            string += '%.2d%.2d' % (seconds // 3600, seconds % 3600)
+                text += '+'
+            text += '%.2d%.2d' % (seconds // 3600, seconds % 3600)
         else:
-            string += 'Z'
+            text += 'Z'
 
-        return cls(string)
+        return cls(text)
 
 
 class GeneralizedTime(char.VisibleString, TimeMixIn):


### PR DESCRIPTION
This PR addresses a couple of bugs that only show up with older Pythons. Specifically:

* missing datetime.strptime()
* missing callable()
* missing str.partition
* incorrect compatibility implementation of bin()