### PR TITLE
Nested optional component encoder fix (take two)

### DIFF
--- a/pyasn1/codec/cer/encoder.py
+++ b/pyasn1/codec/cer/encoder.py
@@ -14,8 +14,8 @@ __all__ = ['encode']
 
 
 class BooleanEncoder(encoder.IntegerEncoder):
-    def encodeValue(self, encodeFun, client, defMode, maxChunkSize, ifNotEmpty=False):
-        if client == 0:
+    def encodeValue(self, encodeFun, value, defMode, maxChunkSize, ifNotEmpty=False):
+        if value == 0:
             substrate = (0,)
         else:
             substrate = (255,)
@@ -23,16 +23,16 @@ class BooleanEncoder(encoder.IntegerEncoder):
 
 
 class BitStringEncoder(encoder.BitStringEncoder):
-    def encodeValue(self, encodeFun, client, defMode, maxChunkSize, ifNotEmpty=False):
+    def encodeValue(self, encodeFun, value, defMode, maxChunkSize, ifNotEmpty=False):
         return encoder.BitStringEncoder.encodeValue(
-            self, encodeFun, client, defMode, 1000, ifNotEmpty=ifNotEmpty
+            self, encodeFun, value, defMode, 1000, ifNotEmpty=ifNotEmpty
         )
 
 
 class OctetStringEncoder(encoder.OctetStringEncoder):
-    def encodeValue(self, encodeFun, client, defMode, maxChunkSize, ifNotEmpty=False):
+    def encodeValue(self, encodeFun, value, defMode, maxChunkSize, ifNotEmpty=False):
         return encoder.OctetStringEncoder.encodeValue(
-            self, encodeFun, client, defMode, 1000, ifNotEmpty=ifNotEmpty
+            self, encodeFun, value, defMode, 1000, ifNotEmpty=ifNotEmpty
         )
 
 
@@ -52,7 +52,7 @@ class TimeEncoderMixIn(object):
     minLength = 12
     maxLength = 19
 
-    def encodeValue(self, encodeFun, client, defMode, maxChunkSize, ifNotEmpty=False):
+    def encodeValue(self, encodeFun, value, defMode, maxChunkSize, ifNotEmpty=False):
         # Encoding constraints:
         # - minutes are mandatory, seconds are optional
         # - subseconds must NOT be zero
@@ -60,10 +60,10 @@ class TimeEncoderMixIn(object):
         # - time in UTC (Z)
         # - only dot is allowed for fractions
 
-        octets = client.asOctets()
+        octets = value.asOctets()
 
         if not self.minLength < len(octets) < self.maxLength:
-            raise error.PyAsn1Error('Length constraint violated: %r' % client)
+            raise error.PyAsn1Error('Length constraint violated: %r' % value)
 
         if self.pluschar in octets or self.minuschar in octets:
             raise error.PyAsn1Error('Must be UTC time: %r' % octets)
@@ -72,10 +72,10 @@ class TimeEncoderMixIn(object):
             raise error.PyAsn1Error('Missing "Z" time zone specifier: %r' % octets)
 
         if self.commachar in octets:
-            raise error.PyAsn1Error('Comma in fractions disallowed: %r' % client)
+            raise error.PyAsn1Error('Comma in fractions disallowed: %r' % value)
 
         return encoder.OctetStringEncoder.encodeValue(
-            self, encodeFun, client, defMode, 1000, ifNotEmpty=ifNotEmpty
+            self, encodeFun, value, defMode, 1000, ifNotEmpty=ifNotEmpty
         )
 
 
@@ -95,27 +95,27 @@ class SetOfEncoder(encoder.SequenceOfEncoder):
         # sort by tags regardless of the Choice value (static sort)
         return sorted(components, key=lambda x: isinstance(x, univ.Choice) and x.minTagSet or x.tagSet)
 
-    def encodeValue(self, encodeFun, client, defMode, maxChunkSize, ifNotEmpty=False):
-        client.verifySizeSpec()
+    def encodeValue(self, encodeFun, value, defMode, maxChunkSize, ifNotEmpty=False):
+        value.verifySizeSpec()
         substrate = null
-        idx = len(client)
+        idx = len(value)
         # This is certainly a hack but how else do I distinguish SetOf
         # from Set if they have the same tags&constraints?
-        if isinstance(client, univ.SequenceAndSetBase):
+        if isinstance(value, univ.SequenceAndSetBase):
             # Set
-            namedTypes = client.componentType
+            namedTypes = value.componentType
             comps = []
             compsMap = {}
             while idx > 0:
                 idx -= 1
                 if namedTypes:
-                    if namedTypes[idx].isOptional and not client[idx].isValue:
+                    if namedTypes[idx].isOptional and not value[idx].isValue:
                         continue
-                    if namedTypes[idx].isDefaulted and client[idx] == namedTypes[idx].asn1Object:
+                    if namedTypes[idx].isDefaulted and value[idx] == namedTypes[idx].asn1Object:
                         continue
 
-                comps.append(client[idx])
-                compsMap[id(client[idx])] = namedTypes[idx].isOptional
+                comps.append(value[idx])
+                compsMap[id(value[idx])] = namedTypes[idx].isOptional
 
             for comp in self._sortComponents(comps):
                 substrate += encodeFun(comp, defMode, maxChunkSize, ifNotEmpty=compsMap[id(comp)])
@@ -125,7 +125,7 @@ class SetOfEncoder(encoder.SequenceOfEncoder):
             while idx > 0:
                 idx -= 1
                 compSubs.append(
-                    encodeFun(client[idx], defMode, maxChunkSize)
+                    encodeFun(value[idx], defMode, maxChunkSize)
                 )
             compSubs.sort()  # perhaps padding's not needed
             substrate = null
@@ -199,9 +199,8 @@ typeMap.update({
 
 class Encoder(encoder.Encoder):
 
-    def __call__(self, client, defMode=False, maxChunkSize=0, ifNotEmpty=False):
-        return encoder.Encoder.__call__(self, client, defMode, maxChunkSize, ifNotEmpty)
-
+    def __call__(self, value, defMode=False, maxChunkSize=0, ifNotEmpty=False):
+        return encoder.Encoder.__call__(self, value, defMode, maxChunkSize, ifNotEmpty)
 
 #: Turns ASN.1 object into CER octet stream.
 #:

--- a/pyasn1/codec/der/encoder.py
+++ b/pyasn1/codec/der/encoder.py
@@ -12,15 +12,15 @@ __all__ = ['encode']
 
 
 class BitStringEncoder(encoder.BitStringEncoder):
-    def encodeValue(self, encodeFun, client, defMode, maxChunkSize, ifNotEmpty=False):
+    def encodeValue(self, encodeFun, value, defMode, maxChunkSize, ifNotEmpty=False):
         return encoder.BitStringEncoder.encodeValue(
-            self, encodeFun, client, defMode, 0, ifNotEmpty=ifNotEmpty
+            self, encodeFun, value, defMode, 0, ifNotEmpty=ifNotEmpty
         )
 
 class OctetStringEncoder(encoder.OctetStringEncoder):
-    def encodeValue(self, encodeFun, client, defMode, maxChunkSize, ifNotEmpty=False):
+    def encodeValue(self, encodeFun, value, defMode, maxChunkSize, ifNotEmpty=False):
         return encoder.OctetStringEncoder.encodeValue(
-            self, encodeFun, client, defMode, 0, ifNotEmpty=ifNotEmpty
+            self, encodeFun, value, defMode, 0, ifNotEmpty=ifNotEmpty
         )
 
 class SetOfEncoder(encoder.SetOfEncoder):
@@ -50,10 +50,10 @@ typeMap.update({
 class Encoder(encoder.Encoder):
     supportIndefLength = False
 
-    def __call__(self, client, defMode=True, maxChunkSize=0, ifNotEmpty=False):
+    def __call__(self, value, defMode=True, maxChunkSize=0, ifNotEmpty=False):
         if not defMode:
             raise error.PyAsn1Error('DER forbids indefinite length mode')
-        return encoder.Encoder.__call__(self, client, defMode, maxChunkSize, ifNotEmpty=ifNotEmpty)
+        return encoder.Encoder.__call__(self, value, defMode, maxChunkSize, ifNotEmpty=ifNotEmpty)
 
 #: Turns ASN.1 object into DER octet stream.
 #:

--- a/pyasn1/codec/der/encoder.py
+++ b/pyasn1/codec/der/encoder.py
@@ -12,15 +12,15 @@ __all__ = ['encode']
 
 
 class BitStringEncoder(encoder.BitStringEncoder):
-    def encodeValue(self, encodeFun, client, defMode, maxChunkSize):
+    def encodeValue(self, encodeFun, client, defMode, maxChunkSize, ifNotEmpty=False):
         return encoder.BitStringEncoder.encodeValue(
-            self, encodeFun, client, defMode, 0
+            self, encodeFun, client, defMode, 0, ifNotEmpty=ifNotEmpty
         )
 
 class OctetStringEncoder(encoder.OctetStringEncoder):
-    def encodeValue(self, encodeFun, client, defMode, maxChunkSize):
+    def encodeValue(self, encodeFun, client, defMode, maxChunkSize, ifNotEmpty=False):
         return encoder.OctetStringEncoder.encodeValue(
-            self, encodeFun, client, defMode, 0
+            self, encodeFun, client, defMode, 0, ifNotEmpty=ifNotEmpty
         )
 
 class SetOfEncoder(encoder.SetOfEncoder):
@@ -50,10 +50,10 @@ typeMap.update({
 class Encoder(encoder.Encoder):
     supportIndefLength = False
 
-    def __call__(self, client, defMode=True, maxChunkSize=0, isOptional=False):
+    def __call__(self, client, defMode=True, maxChunkSize=0, ifNotEmpty=False):
         if not defMode:
             raise error.PyAsn1Error('DER forbids indefinite length mode')
-        return encoder.Encoder.__call__(self, client, defMode, maxChunkSize, isOptional)
+        return encoder.Encoder.__call__(self, client, defMode, maxChunkSize, ifNotEmpty=ifNotEmpty)
 
 #: Turns ASN.1 object into DER octet stream.
 #:

--- a/tests/codec/cer/test_encoder.py
+++ b/tests/codec/cer/test_encoder.py
@@ -274,32 +274,127 @@ class NestedOptionalSequenceEncoderTestCase(unittest.TestCase):
         self.s2[0][1] = 123
         return self.s2
 
-    def testDefModeOptionalWithDefaultAndOptional(self):
+    def testOptionalWithDefaultAndOptional(self):
         s = self.__initOptionalWithDefaultAndOptional()
         assert encoder.encode(s) == ints2octs((48, 128, 48, 128, 4, 4, 116, 101, 115, 116, 2, 1, 123, 0, 0, 0, 0))
-    def testDefModeOptionalWithDefault(self):
+
+    def testOptionalWithDefault(self):
         s = self.__initOptionalWithDefault()
         assert encoder.encode(s) == ints2octs((48, 128, 48, 128, 2, 1, 123, 0, 0, 0, 0))
 
-    def testDefModeOptionalWithOptional(self):
+    def testOptionalWithOptional(self):
         s = self.__initOptionalWithOptional()
         assert encoder.encode(s) == ints2octs((48, 128, 48, 128, 4, 4, 116, 101, 115, 116, 0, 0, 0, 0))
 
-    def testDefModeOptional(self):
+    def testOptional(self):
         s = self.__initOptional()
         assert encoder.encode(s) == ints2octs((48, 128, 0, 0))
 
-    def testDefModeDefaultWithDefaultAndOptional(self):
+    def testDefaultWithDefaultAndOptional(self):
         s = self.__initDefaultWithDefaultAndOptional()
         assert encoder.encode(s) == ints2octs((48, 128, 48, 128, 4, 4, 116, 101, 115, 116, 2, 1, 123, 0, 0, 0, 0))
 
-    def testDefModeDefaultWithDefault(self):
+    def testDefaultWithDefault(self):
         s = self.__initDefaultWithDefault()
         assert encoder.encode(s) == ints2octs((48, 128, 48, 128, 4, 4, 116, 101, 115, 116, 0, 0, 0, 0))
 
-    def testDefModeDefaultWithOptional(self):
+    def testDefaultWithOptional(self):
         s = self.__initDefaultWithOptional()
         assert encoder.encode(s) == ints2octs((48, 128, 48, 128, 2, 1, 123, 0, 0, 0, 0))
+
+
+class NestedOptionalChoiceEncoderTestCase(unittest.TestCase):
+    def setUp(self):
+        layer3 = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.OptionalNamedType('first-name', univ.OctetString()),
+                namedtype.DefaultedNamedType('age', univ.Integer(33)),
+            )
+        )
+
+        layer2 = univ.Choice(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('inner', layer3),
+                namedtype.NamedType('first-name', univ.OctetString())
+            )
+        )
+
+        layer1 = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.OptionalNamedType('inner', layer2),
+            )
+        )
+
+        self.s = layer1
+
+    def __initOptionalWithDefaultAndOptional(self):
+        self.s.clear()
+        self.s[0][0][0] = 'test'
+        self.s[0][0][1] = 123
+        return self.s
+
+    def __initOptionalWithDefault(self):
+        self.s.clear()
+        self.s[0][0][1] = 123
+        return self.s
+
+    def __initOptionalWithOptional(self):
+        self.s.clear()
+        self.s[0][0][0] = 'test'
+        return self.s
+
+    def __initOptional(self):
+        self.s.clear()
+        return self.s
+
+    def testOptionalWithDefaultAndOptional(self):
+        s = self.__initOptionalWithDefaultAndOptional()
+        assert encoder.encode(s) == ints2octs((48, 128, 48, 128, 4, 4, 116, 101, 115, 116, 2, 1, 123, 0, 0, 0, 0))
+
+    def testOptionalWithDefault(self):
+        s = self.__initOptionalWithDefault()
+        assert encoder.encode(s) == ints2octs((48, 128, 48, 128, 2, 1, 123, 0, 0, 0, 0))
+
+    def testOptionalWithOptional(self):
+        s = self.__initOptionalWithOptional()
+        assert encoder.encode(s) == ints2octs((48, 128, 48, 128, 4, 4, 116, 101, 115, 116, 0, 0, 0, 0))
+
+    def testOptional(self):
+        s = self.__initOptional()
+        assert encoder.encode(s) == ints2octs((48, 128, 0, 0))
+
+
+class NestedOptionalSequenceOfEncoderTestCase(unittest.TestCase):
+    def setUp(self):
+        layer2 = univ.SequenceOf(
+            componentType=univ.OctetString()
+        )
+
+        layer1 = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.OptionalNamedType('inner', layer2),
+            )
+        )
+
+        self.s = layer1
+
+    def __initOptionalWithValue(self):
+        self.s.clear()
+        self.s[0][0] = 'test'
+        return self.s
+
+    def __initOptional(self):
+        self.s.clear()
+        return self.s
+
+    def testOptionalWithValue(self):
+        s = self.__initOptionalWithValue()
+        assert encoder.encode(s) == ints2octs((48, 128, 48, 128, 4, 4, 116, 101, 115, 116, 0, 0, 0, 0))
+
+    def testOptional(self):
+        s = self.__initOptional()
+        assert encoder.encode(s) == ints2octs((48, 128, 0, 0))
+
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 

--- a/tests/codec/der/test_encoder.py
+++ b/tests/codec/der/test_encoder.py
@@ -64,6 +64,189 @@ class SetWithChoiceEncoderTestCase(unittest.TestCase):
         self.s.getComponentByName('status').setComponentByPosition(1, True)
         assert encoder.encode(self.s) == ints2octs((49, 6, 1, 1, 255, 2, 1, 5))
 
+
+class NestedOptionalSequenceEncoderTestCase(unittest.TestCase):
+    def setUp(self):
+        inner = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.OptionalNamedType('first-name', univ.OctetString()),
+                namedtype.DefaultedNamedType('age', univ.Integer(33)),
+            )
+        )
+
+        outerWithOptional = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.OptionalNamedType('inner', inner),
+            )
+        )
+
+        outerWithDefault = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.DefaultedNamedType('inner', inner),
+            )
+        )
+
+        self.s1 = outerWithOptional
+        self.s2 = outerWithDefault
+
+    def __initOptionalWithDefaultAndOptional(self):
+        self.s1.clear()
+        self.s1[0][0] = 'test'
+        self.s1[0][1] = 123
+        return self.s1
+
+    def __initOptionalWithDefault(self):
+        self.s1.clear()
+        self.s1[0][1] = 123
+        return self.s1
+
+    def __initOptionalWithOptional(self):
+        self.s1.clear()
+        self.s1[0][0] = 'test'
+        return self.s1
+
+    def __initOptional(self):
+        self.s1.clear()
+        return self.s1
+
+    def __initDefaultWithDefaultAndOptional(self):
+        self.s2.clear()
+        self.s2[0][0] = 'test'
+        self.s2[0][1] = 123
+        return self.s2
+
+    def __initDefaultWithDefault(self):
+        self.s2.clear()
+        self.s2[0][0] = 'test'
+        return self.s2
+
+    def __initDefaultWithOptional(self):
+        self.s2.clear()
+        self.s2[0][1] = 123
+        return self.s2
+
+    def testDefModeOptionalWithDefaultAndOptional(self):
+        s = self.__initOptionalWithDefaultAndOptional()
+        assert encoder.encode(s) == ints2octs((48, 11, 48, 9, 4, 4, 116, 101, 115, 116, 2, 1, 123))
+
+    def testDefModeOptionalWithDefault(self):
+        s = self.__initOptionalWithDefault()
+        assert encoder.encode(s) == ints2octs((48, 5, 48, 3, 2, 1, 123))
+
+    def testDefModeOptionalWithOptional(self):
+        s = self.__initOptionalWithOptional()
+        assert encoder.encode(s) == ints2octs((48, 8, 48, 6, 4, 4, 116, 101, 115, 116))
+
+    def testDefModeOptional(self):
+        s = self.__initOptional()
+        assert encoder.encode(s) == ints2octs((48, 0))
+
+    def testDefModeDefaultWithDefaultAndOptional(self):
+        s = self.__initDefaultWithDefaultAndOptional()
+        assert encoder.encode(s) == ints2octs((48, 11, 48, 9, 4, 4, 116, 101, 115, 116, 2, 1, 123))
+
+    def testDefModeDefaultWithDefault(self):
+        s = self.__initDefaultWithDefault()
+        assert encoder.encode(s) == ints2octs((48, 8, 48, 6, 4, 4, 116, 101, 115, 116))
+
+    def testDefModeDefaultWithOptional(self):
+        s = self.__initDefaultWithOptional()
+        assert encoder.encode(s) == ints2octs((48, 5, 48, 3, 2, 1, 123))
+
+
+class NestedOptionalChoiceEncoderTestCase(unittest.TestCase):
+    def setUp(self):
+        layer3 = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.OptionalNamedType('first-name', univ.OctetString()),
+                namedtype.DefaultedNamedType('age', univ.Integer(33)),
+            )
+        )
+
+        layer2 = univ.Choice(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('inner', layer3),
+                namedtype.NamedType('first-name', univ.OctetString())
+            )
+        )
+
+        layer1 = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.OptionalNamedType('inner', layer2),
+            )
+        )
+
+        self.s = layer1
+
+    def __initOptionalWithDefaultAndOptional(self):
+        self.s.clear()
+        self.s[0][0][0] = 'test'
+        self.s[0][0][1] = 123
+        return self.s
+
+    def __initOptionalWithDefault(self):
+        self.s.clear()
+        self.s[0][0][1] = 123
+        return self.s
+
+    def __initOptionalWithOptional(self):
+        self.s.clear()
+        self.s[0][0][0] = 'test'
+        return self.s
+
+    def __initOptional(self):
+        self.s.clear()
+        return self.s
+
+    def testDefModeOptionalWithDefaultAndOptional(self):
+        s = self.__initOptionalWithDefaultAndOptional()
+        assert encoder.encode(s) == ints2octs((48, 11, 48, 9, 4, 4, 116, 101, 115, 116, 2, 1, 123))
+
+    def testDefModeOptionalWithDefault(self):
+        s = self.__initOptionalWithDefault()
+        assert encoder.encode(s) == ints2octs((48, 5, 48, 3, 2, 1, 123))
+
+    def testDefModeOptionalWithOptional(self):
+        s = self.__initOptionalWithOptional()
+        assert encoder.encode(s) == ints2octs((48, 8, 48, 6, 4, 4, 116, 101, 115, 116))
+
+    def testDefModeOptional(self):
+        s = self.__initOptional()
+        assert encoder.encode(s) == ints2octs((48, 0))
+
+
+class NestedOptionalSequenceOfEncoderTestCase(unittest.TestCase):
+    def setUp(self):
+        layer2 = univ.SequenceOf(
+            componentType=univ.OctetString()
+        )
+
+        layer1 = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.OptionalNamedType('inner', layer2),
+            )
+        )
+
+        self.s = layer1
+
+    def __initOptionalWithValue(self):
+        self.s.clear()
+        self.s[0][0] = 'test'
+        return self.s
+
+    def __initOptional(self):
+        self.s.clear()
+        return self.s
+
+    def testDefModeOptionalWithValue(self):
+        s = self.__initOptionalWithValue()
+        assert encoder.encode(s) == ints2octs((48, 8, 48, 6, 4, 4, 116, 101, 115, 116))
+
+    def testDefModeOptional(self):
+        s = self.__initOptional()
+        assert encoder.encode(s) == ints2octs((48, 0))
+
+
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR improves https://github.com/etingof/pyasn1/pull/56 in part of recursively handling `OPTIONAL SEQUENCE` field e.g. when field's value is a `CHOICE` or `SEQUENCE OF` type.