### PR TITLE
Fixes to threading concurrency issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,9 @@
 
-Revision 0.3.2, released XX-07-2017
+Revision 0.3.2, released XX-08-2017
 -----------------------------------
 
+- Fixed threading concurrency issues by moving lazy computation
+  into instance initializer.
 - Fixed .isValue property to return True for empty SetOf/SequenceOf
   objects
 - Fixed GeneralizedTime/UTCTime CER/DER codecs to actually get invoked

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@
 Revision 0.3.2, released XX-08-2017
 -----------------------------------
 
-- Fixed threading concurrency issues by moving lazy computation
-  into instance initializer.
+- Rectified thread safety issues by moving lazy, run-time computation
+  into object initializer.
 - Fixed .isValue property to return True for empty SetOf/SequenceOf
   objects
 - Fixed GeneralizedTime/UTCTime CER/DER codecs to actually get invoked

--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -1012,7 +1012,7 @@ class Decoder(object):
                     logger('codec %s yields type %s, value:\n%s\n...remaining substrate is: %s' % (concreteDecoder.__class__.__name__, value.__class__.__name__, value.prettyPrint(), substrate and debug.hexdump(substrate) or '<none>'))
             if state is stErrorCondition:
                 raise error.PyAsn1Error(
-                    '%s not in asn1Spec: %s' % (tagSet, asn1Spec)
+                    '%s not in asn1Spec: %r' % (tagSet, asn1Spec)
                 )
         if logger:
             debug.scope.pop()

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -85,12 +85,7 @@ class Asn1ItemBase(Asn1Item):
     def tagMap(self):
         """Return a :class:`~pyasn1.type.tagmap.TagMap` object mapping ASN.1 tags to ASN.1 objects within callee object.
         """
-        try:
-            return self._tagMap
-
-        except AttributeError:
-            self._tagMap = tagmap.TagMap({self.tagSet: self})
-            return self._tagMap
+        return tagmap.TagMap({self.tagSet: self})
 
     def isSameTypeWith(self, other, matchTags=True, matchConstraints=True):
         """Examine |ASN.1| type for equality with other ASN.1 type.
@@ -235,7 +230,6 @@ class AbstractSimpleAsn1Item(Asn1ItemBase):
                 exType, exValue, exTb = sys.exc_info()
                 raise exType('%s at %s' % (exValue, self.__class__.__name__))
 
-        self.__hashedValue = None
         self._value = value
         self._len = None
 
@@ -278,9 +272,7 @@ class AbstractSimpleAsn1Item(Asn1ItemBase):
             return self._value and True or False
 
     def __hash__(self):
-        if self.__hashedValue is None:
-            self.__hashedValue = hash(self._value)
-        return self.__hashedValue
+        return hash(self._value)
 
     @property
     def isValue(self):

--- a/pyasn1/type/constraint.py
+++ b/pyasn1/type/constraint.py
@@ -25,7 +25,7 @@ class AbstractConstraint(object):
     def __init__(self, *values):
         self._valueMap = set()
         self._setValues(values)
-        self.__hashedValues = None
+        self.__hash = hash((self.__class__.__name__, self._values))
 
     def __call__(self, value, idx=None):
         if not self._values:
@@ -71,9 +71,7 @@ class AbstractConstraint(object):
             return self._values and True or False
 
     def __hash__(self):
-        if self.__hashedValues is None:
-            self.__hashedValues = hash((self.__class__.__name__, self._values))
-        return self.__hashedValues
+        return self.__hash
 
     def _setValues(self, values):
         self._values = values

--- a/pyasn1/type/namedtype.py
+++ b/pyasn1/type/namedtype.py
@@ -195,6 +195,8 @@ class NamedTypes(object):
         tagToPosMap = {}
         for idx, namedType in enumerate(self.__namedTypes):
             tagMap = namedType.asn1Object.tagMap
+            if isinstance(tagMap, NamedTypes.PostponedError):
+                return tagMap
             if not tagMap:
                 continue
             for _tagSet in tagMap.presentTypes:
@@ -419,6 +421,8 @@ class NamedTypes(object):
         defaultType = None
         for namedType in self.__namedTypes:
             tagMap = namedType.asn1Object.tagMap
+            if isinstance(tagMap, NamedTypes.PostponedError):
+                return tagMap
             for tagSet in tagMap:
                 if unique and tagSet in presentTypes:
                     return NamedTypes.PostponedError('Non-unique tagSet %s of %s at %s' % (tagSet, namedType, self))

--- a/pyasn1/type/namedtype.py
+++ b/pyasn1/type/namedtype.py
@@ -5,7 +5,7 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
-from pyasn1.type import tagmap
+from pyasn1.type import tag, tagmap
 from pyasn1 import error
 
 __all__ = ['NamedType', 'OptionalNamedType', 'DefaultedNamedType', 'NamedTypes']
@@ -109,13 +109,17 @@ class NamedTypes(object):
     def __init__(self, *namedTypes):
         self.__namedTypes = namedTypes
         self.__namedTypesLen = len(self.__namedTypes)
-        self.__minTagSet = None
-        self.__tagToPosMapImpl = None
-        self.__nameToPosMapImpl = None
-        self.__ambigiousTypesImpl = None
-        self.__tagMap = {}
-        self.__hasOptionalOrDefault = None
-        self.__requiredComponents = None
+        self.__minTagSet = self.__computeMinTagSet()
+        self.__nameToPosMap = self.__computeNameToPosMap()
+        self.__tagToPosMap = self.__computeTagToPosMap()
+        self.__ambiguousTypes = self.__computeAmbiguousTypes()
+        self.__uniqueTagMap = self.__computeTagMaps(unique=True)
+        self.__nonUniqueTagMap = self.__computeTagMaps(unique=False)
+        self.__hasOptionalOrDefault = bool([True for namedType in self.__namedTypes
+                                            if namedType.isDefaulted or namedType.isOptional])
+        self.__requiredComponents = frozenset(
+                [idx for idx, nt in enumerate(self.__namedTypes) if not nt.isOptional and not nt.isDefaulted]
+            )
 
     def __repr__(self):
         return '%s(%s)' % (
@@ -180,44 +184,48 @@ class NamedTypes(object):
     def clone(self):
         return self.__class__(*self.__namedTypes)
 
-    @property
-    def __tagToPosMap(self):
-        if self.__tagToPosMapImpl is None:
-            self.__tagToPosMapImpl = {}
-            for idx, namedType in enumerate(self.__namedTypes):
-                tagMap = namedType.asn1Object.tagMap
-                if not tagMap:
-                    continue
-                for _tagSet in tagMap.presentTypes:
-                    if _tagSet in self.__tagToPosMapImpl:
-                        raise error.PyAsn1Error('Duplicate type %s in %s' % (_tagSet, namedType))
-                    self.__tagToPosMapImpl[_tagSet] = idx
+    class PostponedError(object):
+        def __init__(self, errorMsg):
+            self.__errorMsg = errorMsg
 
-        return self.__tagToPosMapImpl
+        def __getitem__(self, item):
+            raise  error.PyAsn1Error(self.__errorMsg)
 
-    @property
-    def __nameToPosMap(self):
-        if self.__nameToPosMapImpl is None:
-            self.__nameToPosMapImpl = {}
-            for idx, namedType in enumerate(self.__namedTypes):
-                if namedType.name in self.__nameToPosMapImpl:
-                    raise error.PyAsn1Error('Duplicate name %s in %s' % (namedType.name, namedType))
-                self.__nameToPosMapImpl[namedType.name] = idx
+    def __computeTagToPosMap(self):
+        tagToPosMap = {}
+        for idx, namedType in enumerate(self.__namedTypes):
+            tagMap = namedType.asn1Object.tagMap
+            if not tagMap:
+                continue
+            for _tagSet in tagMap.presentTypes:
+                if _tagSet in tagToPosMap:
+                    return NamedTypes.PostponedError('Duplicate component tag %s at %s' % (_tagSet, namedType))
+                tagToPosMap[_tagSet] = idx
 
-        return self.__nameToPosMapImpl
+        return tagToPosMap
 
-    @property
-    def __ambigiousTypes(self):
-        if self.__ambigiousTypesImpl is None:
-            self.__ambigiousTypesImpl = {}
-            ambigiousTypes = ()
-            for idx, namedType in reversed(tuple(enumerate(self.__namedTypes))):
-                if namedType.isOptional or namedType.isDefaulted:
-                    ambigiousTypes = (namedType,) + ambigiousTypes
-                else:
-                    ambigiousTypes = (namedType,)
-                self.__ambigiousTypesImpl[idx] = NamedTypes(*ambigiousTypes)
-        return self.__ambigiousTypesImpl
+    def __computeNameToPosMap(self):
+        nameToPosMap = {}
+        for idx, namedType in enumerate(self.__namedTypes):
+            if namedType.name in nameToPosMap:
+                return NamedTypes.PostponedError('Duplicate component name %s at %s' % (namedType.name, namedType))
+            nameToPosMap[namedType.name] = idx
+
+        return nameToPosMap
+
+    def __computeAmbiguousTypes(self):
+        ambigiousTypes = {}
+        partialAmbigiousTypes = ()
+        for idx, namedType in reversed(tuple(enumerate(self.__namedTypes))):
+            if namedType.isOptional or namedType.isDefaulted:
+                partialAmbigiousTypes = (namedType,) + partialAmbigiousTypes
+            else:
+                partialAmbigiousTypes = (namedType,)
+            if len(partialAmbigiousTypes) == len(self.__namedTypes):
+                ambigiousTypes[idx] = self
+            else:
+                ambigiousTypes[idx] = NamedTypes(*partialAmbigiousTypes)
+        return ambigiousTypes
 
     def getTypeByPosition(self, idx):
         """Return ASN.1 type object by its position in fields set.
@@ -339,7 +347,7 @@ class NamedTypes(object):
             If given position is out of fields range
         """
         try:
-            return self.__ambigiousTypes[idx].tagMap
+            return self.__ambiguousTypes[idx].tagMap
 
         except KeyError:
             raise error.PyAsn1Error('Type position out of range')
@@ -372,10 +380,23 @@ class NamedTypes(object):
             or *idx* is out of fields range
         """
         try:
-            return idx + self.__ambigiousTypes[idx].getPositionByType(tagSet)
+            return idx + self.__ambiguousTypes[idx].getPositionByType(tagSet)
 
         except KeyError:
             raise error.PyAsn1Error('Type position out of range')
+
+    def __computeMinTagSet(self):
+        minTagSet = None
+        for namedType in self.__namedTypes:
+            asn1Object = namedType.asn1Object
+            try:
+                tagSet = asn1Object.minTagSet
+
+            except AttributeError:
+                tagSet = asn1Object.tagSet
+            if minTagSet is None or tagSet < minTagSet:
+                minTagSet = tagSet
+        return minTagSet or tag.TagSet()
 
     @property
     def minTagSet(self):
@@ -390,39 +411,26 @@ class NamedTypes(object):
         : :class:`~pyasn1.type.tagset.TagSet`
             Minimal TagSet among ASN.1 types in callee *NamedTypes*
         """
-        if self.__minTagSet is None:
-            for namedType in self.__namedTypes:
-                asn1Object = namedType.asn1Object
-                try:
-                    tagSet = asn1Object.minTagSet
-
-                except AttributeError:
-                    tagSet = asn1Object.tagSet
-                if self.__minTagSet is None or tagSet < self.__minTagSet:
-                    self.__minTagSet = tagSet
         return self.__minTagSet
 
-    def __getTagMap(self, unique):
-        if unique not in self.__tagMap:
-            presentTypes = {}
-            skipTypes = {}
-            defaultType = None
-            for namedType in self.__namedTypes:
-                tagMap = namedType.asn1Object.tagMap
-                for tagSet in tagMap:
-                    if unique and tagSet in presentTypes:
-                        raise error.PyAsn1Error('Non-unique tagSet %s' % (tagSet,))
-                    presentTypes[tagSet] = namedType.asn1Object
-                skipTypes.update(tagMap.skipTypes)
+    def __computeTagMaps(self, unique):
+        presentTypes = {}
+        skipTypes = {}
+        defaultType = None
+        for namedType in self.__namedTypes:
+            tagMap = namedType.asn1Object.tagMap
+            for tagSet in tagMap:
+                if unique and tagSet in presentTypes:
+                    return NamedTypes.PostponedError('Non-unique tagSet %s of %s at %s' % (tagSet, namedType, self))
+                presentTypes[tagSet] = namedType.asn1Object
+            skipTypes.update(tagMap.skipTypes)
 
-                if defaultType is None:
-                    defaultType = tagMap.defaultType
-                elif tagMap.defaultType is not None:
-                    raise error.PyAsn1Error('Duplicate default ASN.1 type at %s' % (self,))
+            if defaultType is None:
+                defaultType = tagMap.defaultType
+            elif tagMap.defaultType is not None:
+                raise error.PyAsn1Error('Duplicate default ASN.1 type at %s' % (self,))
 
-            self.__tagMap[unique] = tagmap.TagMap(presentTypes, skipTypes, defaultType)
-
-        return self.__tagMap[unique]
+        return tagmap.TagMap(presentTypes, skipTypes, defaultType)
 
     @property
     def tagMap(self):
@@ -447,7 +455,7 @@ class NamedTypes(object):
 
            Integer.tagSet -> Choice
         """
-        return self.__getTagMap(unique=False)
+        return self.__nonUniqueTagMap
 
     @property
     def tagMapUnique(self):
@@ -478,12 +486,10 @@ class NamedTypes(object):
         Duplicate *TagSet* objects found in the tree of children
         types would cause error.
         """
-        return self.__getTagMap(unique=True)
+        return self.__uniqueTagMap
 
     @property
     def hasOptionalOrDefault(self):
-        if self.__hasOptionalOrDefault is None:
-            self.__hasOptionalOrDefault = bool([True for namedType in self.__namedTypes if namedType.isDefaulted or namedType.isOptional])
         return self.__hasOptionalOrDefault
 
     @property
@@ -492,8 +498,4 @@ class NamedTypes(object):
 
     @property
     def requiredComponents(self):
-        if self.__requiredComponents is None:
-            self.__requiredComponents = frozenset(
-                [idx for idx, nt in enumerate(self.__namedTypes) if not nt.isOptional and not nt.isDefaulted]
-            )
         return self.__requiredComponents

--- a/pyasn1/type/tag.py
+++ b/pyasn1/type/tag.py
@@ -61,7 +61,7 @@ class Tag(object):
         self.__tagFormat = tagFormat
         self.__tagId = tagId
         self.__tagClassId = tagClass, tagId
-        self.__lazyHash = None
+        self.__hash = hash(self.__tagClassId)
 
     def __str__(self):
         return '[%s:%s:%s]' % (self.__tagClass, self.__tagFormat, self.__tagId)
@@ -90,9 +90,7 @@ class Tag(object):
         return self.__tagClassId >= other
 
     def __hash__(self):
-        if self.__lazyHash is None:
-            self.__lazyHash = hash(self.__tagClassId)
-        return self.__lazyHash
+        return self.__hash
 
     def __getitem__(self, idx):
         if idx == 0:

--- a/pyasn1/type/tag.py
+++ b/pyasn1/type/tag.py
@@ -178,7 +178,7 @@ class TagSet(object):
             [(superTag.tagClass, superTag.tagId) for superTag in superTags]
         )
         self.__lenOfSuperTags = len(superTags)
-        self.__lazyHash = None
+        self.__hash = hash(self.__superTags)
 
     def __str__(self):
         return self.__superTags and '+'.join([str(x) for x in self.__superTags]) or '[untagged]'
@@ -219,9 +219,7 @@ class TagSet(object):
         return self.__superTagsSignature >= other
 
     def __hash__(self):
-        if self.__lazyHash is None:
-            self.__lazyHash = hash(self.__superTags)
-        return self.__lazyHash
+        return self.__hash
 
     def __len__(self):
         return self.__lenOfSuperTags
@@ -266,7 +264,7 @@ class TagSet(object):
             New *TagSet* object
         """
         if superTag.tagClass == tagClassUniversal:
-            raise error.PyAsn1Error('Can\'t tag with UNIVERSAL class tag')
+            raise error.PyAsn1Error("Can't tag with UNIVERSAL class tag")
         if superTag.tagFormat != tagFormatConstructed:
             superTag = Tag(superTag.tagClass, tagFormatConstructed, superTag.tagId)
         return self + superTag

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -951,9 +951,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
             return str(self._value)
 
         def asNumbers(self):
-            if self.__asNumbersCache is None:
-                self.__asNumbersCache = tuple([ord(x) for x in self._value])
-            return self.__asNumbersCache
+            return tuple([ord(x) for x in self._value])
 
     else:
         def prettyIn(self, value):
@@ -991,9 +989,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
             return bytes(self._value)
 
         def asNumbers(self):
-            if self.__asNumbersCache is None:
-                self.__asNumbersCache = tuple(self._value)
-            return self.__asNumbersCache
+            return tuple(self._value)
 
     def prettyOut(self, value):
         if sys.version_info[0] <= 2:

--- a/tests/type/test_namedtype.py
+++ b/tests/type/test_namedtype.py
@@ -92,7 +92,7 @@ class NamedTypesCaseBase(unittest.TestCase):
 
     def testGetTagMapWithDups(self):
         try:
-            self.e.tagMapUnique
+            self.e.tagMapUnique[0]
         except PyAsn1Error:
             pass
         else:


### PR DESCRIPTION
This PR moves all lazy initialization into object initializer (eg. `__init__`) for the purpose to avoiding potential collisions when running in a multithreaded environment. The backside is that module loading takes more cycles.

The alternative approach would be to introduce explicit locking, though that seems unnecessary expensive at runtime.