### PR TITLE
SequenceOf/SetOf to take positionals for backward compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@
 Revision 0.3.2, released XX-08-2017
 -----------------------------------
 
+- Fixed SequenceOf/SetOf types initialization syntax to remain
+  backward compatible with pyasn1 0.2.*
 - Rectified thread safety issues by moving lazy, run-time computation
   into object initializer.
 - Fixed .isValue property to return True for empty SetOf/SequenceOf

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -1718,6 +1718,17 @@ class SequenceOfAndSetOfBase(base.AbstractConstructedAsn1Item):
         Object representing collection size constraint
      """
 
+    def __init__(self, *args, **kwargs):
+        # support positional params for backward compatibility
+        if args:
+            for key, value in zip(('componentType', 'tagSet',
+                                   'subtypeSpec', 'sizeSpec'), args):
+                if key in kwargs:
+                    raise error.PyAsn1Error('Conflicting positional and keyword params!')
+                kwargs['componentType'] = value
+
+        base.AbstractConstructedAsn1Item.__init__(self, **kwargs)
+
     # Python list protocol
 
     def clear(self):

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -939,6 +939,20 @@ class SequenceOf(unittest.TestCase):
         assert len(s) == 1
         assert s == [str2octs('abc')]
 
+    def testLegacyInitializer(self):
+        n = univ.SequenceOf(
+            componentType=univ.OctetString()
+        )
+        o = univ.SequenceOf(
+            univ.OctetString()  # this is the old way
+        )
+
+        assert n.isSameTypeWith(o) and o.isSameTypeWith(n)
+
+        n[0] = 'fox'
+        o[0] = 'fox'
+
+        assert n == o
 
 class Sequence(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Release 0.3.1 changed `SequenceOf/SetOf` instantiation signature losing positional parameters in favour to kwargs.

This PR recovers positional parameters support to preserve compatibility with the existing applications.