### PR TITLE
NoValue should not throw exception on conversion to bool

### DIFF
--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -243,9 +243,11 @@ class AbstractSimpleAsn1Item(Asn1ItemBase):
 
     if sys.version_info[0] <= 2:
         def __nonzero__(self):
+            if not self.isValue: return False
             return self._value and True or False
     else:
         def __bool__(self):
+            if not self.isValue: return False
             return self._value and True or False
 
     def __hash__(self):


### PR DESCRIPTION
This improves backward compatibility with 0.1.8
It's really hard to find all occurrences similar to

if signed_data.getComponentByName('crls'):
  ...

in large codebase.