### PR TITLE
Component-less SET/SEQUENCE object to duck-type Python dict

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 
-Revision 0.3.4, released XX-08-2017
+Revision 0.3.4, released XX-09-2017
 -----------------------------------
 
+- Added missing component-less SEQUENCE/SET objects dict duck-typing support
 - Fixed unnecessary duplicate tags detection at NamesType.tagMap
 - Fixed crash at SEQUENCE and SEQUENCE OF CER encoder when running
   in schemaless mode

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -2009,9 +2009,52 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
     #: object representing named ASN.1 types allowed within |ASN.1| type
     componentType = namedtype.NamedTypes()
 
+
+    class DynamicNames(object):
+        """Fields names/positions mapping for component-less objects"""
+        def __init__(self):
+            self._keyToIdxMap = {}
+            self._idxToKeyMap = {}
+
+        def __len__(self):
+            return len(self._keyToIdxMap)
+
+        def __contains__(self, item):
+            return item in self._keyToIdxMap or item in self._idxToKeyMap
+
+        def __iter__(self):
+            return (self._idxToKeyMap[idx] for idx in range(len(self._idxToKeyMap)))
+
+        def __getitem__(self, item):
+            try:
+                return self._keyToIdxMap[item]
+
+            except KeyError:
+                return self._idxToKeyMap[item]
+
+        def getNameByPosition(self, idx):
+            try:
+                return self._idxToKeyMap[idx]
+
+            except KeyError:
+                raise error.PyAsn1Error('Type position out of range')
+
+        def getPositionByName(self, name):
+            try:
+                return self._keyToIdxMap[name]
+
+            except KeyError:
+                raise error.PyAsn1Error('Name %s not found' % (name,))
+
+        def addField(self, idx):
+            self._keyToIdxMap['field-%d' % idx] = idx
+            self._idxToKeyMap[idx] = 'field-%d' % idx
+
+
     def __init__(self, **kwargs):
         base.AbstractConstructedAsn1Item.__init__(self, **kwargs)
         self._componentTypeLen = len(self.componentType)
+        self._dynamicNames = self._componentTypeLen or self.DynamicNames()
 
     def __getitem__(self, idx):
         if octets.isStringType(idx):
@@ -2026,23 +2069,29 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
             base.AbstractConstructedAsn1Item.__setitem__(self, idx, value)
 
     def __contains__(self, key):
-        return key in self.componentType
+        if self._componentTypeLen:
+            return key in self.componentType
+        else:
+            return key in self._dynamicNames
 
     def __iter__(self):
-        return iter(self.componentType)
+        return iter(self.componentType or self._dynamicNames)
 
     # Python dict protocol
 
     def values(self):
-        for idx in range(self._componentTypeLen):
+        for idx in range(self._componentTypeLen or len(self._dynamicNames)):
             yield self[idx]
 
     def keys(self):
-        return iter(self.componentType)
+        return iter(self)
 
     def items(self):
-        for idx in range(self._componentTypeLen):
-            yield self.componentType[idx].getName(), self[idx]
+        for idx in range(self._componentTypeLen or len(self._dynamicNames)):
+            if self._componentTypeLen:
+                yield self.componentType[idx].name, self[idx]
+            else:
+                yield self._dynamicNames[idx], self[idx]
 
     def update(self, *iterValue, **mappingValue):
         for k, v in iterValue:
@@ -2052,6 +2101,7 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
 
     def clear(self):
         self._componentValues = []
+        self._dynamicNames = self.DynamicNames()
 
     def _cloneComponentValues(self, myClone, cloneValueFlag):
         for idx, componentValue in enumerate(self._componentValues):
@@ -2078,9 +2128,16 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
         : :py:class:`~pyasn1.type.base.PyAsn1Item`
             Instantiate |ASN.1| component type or return existing component value
         """
-        return self.getComponentByPosition(
-            self.componentType.getPositionByName(name)
-        )
+        if self._componentTypeLen:
+            idx = self.componentType.getPositionByName(name)
+        else:
+            try:
+                idx = self._dynamicNames.getPositionByName(name)
+
+            except KeyError:
+                raise error.PyAsn1Error('Name %s not found' % (name,))
+
+        return self.getComponentByPosition(idx)
 
     def setComponentByName(self, name, value=noValue,
                            verifyConstraints=True,
@@ -2112,8 +2169,17 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
         -------
         self
         """
+        if self._componentTypeLen:
+            idx = self.componentType.getPositionByName(name)
+        else:
+            try:
+                idx = self._dynamicNames.getPositionByName(name)
+
+            except KeyError:
+                raise error.PyAsn1Error('Name %s not found' % (name,))
+
         return self.setComponentByPosition(
-            self.componentType.getPositionByName(name), value, verifyConstraints, matchTags, matchConstraints
+            idx, value, verifyConstraints, matchTags, matchConstraints
         )
 
     def getComponentByPosition(self, idx):
@@ -2225,10 +2291,11 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
                 exType, exValue, exTb = sys.exc_info()
                 raise exType('%s at %s' % (exValue, self.__class__.__name__))
 
-        if componentTypeLen:
+        if componentTypeLen or idx in self._dynamicNames:
             self._componentValues[idx] = value
         elif len(self._componentValues) == idx:
             self._componentValues.append(value)
+            self._dynamicNames.addField(idx)
         else:
             raise error.PyAsn1Error('Component index out of range')
 
@@ -2293,7 +2360,7 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
                 if self.componentType:
                     representation += self.componentType.getNameByPosition(idx)
                 else:
-                    representation += 'field-%d' % idx
+                    representation += self._idxToKeyMap[idx]
                 representation = '%s=%s\n' % (
                     representation, componentValue.prettyPrint(scope)
                 )

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -1101,6 +1101,56 @@ class Sequence(unittest.TestCase):
         assert s['name'] == str2octs('abc')
 
 
+class SequenceWithoutSchema(unittest.TestCase):
+
+    def testIter(self):
+        s = univ.Sequence()
+        s.setComponentByPosition(0, univ.OctetString('abc'))
+        s.setComponentByPosition(1, univ.Integer(123))
+        assert list(s) == ['field-0', 'field-1']
+
+    def testKeys(self):
+        s = univ.Sequence()
+        s.setComponentByPosition(0, univ.OctetString('abc'))
+        s.setComponentByPosition(1, univ.Integer(123))
+        assert list(s.keys()) == ['field-0', 'field-1']
+
+    def testValues(self):
+        s = univ.Sequence()
+        s.setComponentByPosition(0, univ.OctetString('abc'))
+        s.setComponentByPosition(1, univ.Integer(123))
+        assert list(s.values()) == [str2octs('abc'), 123]
+
+    def testItems(self):
+        s = univ.Sequence()
+        s.setComponentByPosition(0, univ.OctetString('abc'))
+        s.setComponentByPosition(1, univ.Integer(123))
+        assert list(s.items()) == [('field-0', str2octs('abc')), ('field-1', 123)]
+
+    def testUpdate(self):
+        s = univ.Sequence()
+        assert not s
+        s.setComponentByPosition(0, univ.OctetString('abc'))
+        s.setComponentByPosition(1, univ.Integer(123))
+        assert s
+        assert list(s.keys()) == ['field-0', 'field-1']
+        assert list(s.values()) == [str2octs('abc'), 123]
+        assert list(s.items()) == [('field-0', str2octs('abc')), ('field-1', 123)]
+        s['field-0'] = univ.OctetString('def')
+        assert list(s.values()) == [str2octs('def'), 123]
+        s['field-1'] = univ.OctetString('ghi')
+        assert list(s.values()) == [str2octs('def'), str2octs('ghi')]
+        try:
+            s['field-2'] = univ.OctetString('xxx')
+        except error.PyAsn1Error:
+            pass
+        else:
+            assert False, 'unknown field at schema-less object tolerated'
+        assert 'field-0' in s
+        s.clear()
+        assert 'field-0' not in s
+
+
 class SetOf(unittest.TestCase):
     def setUp(self):
         self.s1 = univ.SetOf(componentType=univ.OctetString(''))


### PR DESCRIPTION
This PR unifies SEQUENCE/SET objects behavior (when they lack componentType property and can be configured dynamically) with the ones having rigid components.