### PR TITLE
Codecs signatures unified and pass **options through

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,9 @@
 
+Revision 0.3.5, released XX-09-2017
+-----------------------------------
+
+- Codecs signatures unified and pass **options through the call chain
+
 Revision 0.3.4, released 07-09-2017
 -----------------------------------
 

--- a/pyasn1/__init__.py
+++ b/pyasn1/__init__.py
@@ -1,7 +1,7 @@
 import sys
 
 # http://www.python.org/dev/peps/pep-0396/
-__version__ = '0.3.4'
+__version__ = '0.3.5'
 
 if sys.version_info[:2] < (2, 4):
     raise RuntimeError('PyASN1 requires Python 2.4 or later')

--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -18,12 +18,16 @@ noValue = base.noValue
 class AbstractDecoder(object):
     protoComponent = None
 
-    def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                     length, state, decodeFun, substrateFun):
+    def valueDecoder(self, substrate, asn1Spec,
+                     tagSet=None, length=None, state=None,
+                     decodeFun=None, substrateFun=None,
+                     **options):
         raise error.PyAsn1Error('Decoder not implemented for %s' % (tagSet,))
 
-    def indefLenValueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                             length, state, decodeFun, substrateFun):
+    def indefLenValueDecoder(self, substrate, asn1Spec,
+                             tagSet=None, length=None, state=None,
+                             decodeFun=None, substrateFun=None,
+                             **options):
         raise error.PyAsn1Error('Indefinite length mode decoder not implemented for %s' % (tagSet,))
 
 
@@ -44,27 +48,37 @@ class AbstractSimpleDecoder(AbstractDecoder):
 class ExplicitTagDecoder(AbstractSimpleDecoder):
     protoComponent = univ.Any('')
 
-    def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                     length, state, decodeFun, substrateFun):
+    def valueDecoder(self, substrate, asn1Spec,
+                     tagSet=None, length=None, state=None,
+                     decodeFun=None, substrateFun=None,
+                     **options):
         if substrateFun:
             return substrateFun(
                 self._createComponent(asn1Spec, tagSet, ''),
                 substrate, length
             )
+
         head, tail = substrate[:length], substrate[length:]
-        value, _ = decodeFun(head, asn1Spec, tagSet, length)
+
+        value, _ = decodeFun(head, asn1Spec, tagSet, length, **options)
+
         return value, tail
 
-    def indefLenValueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                             length, state, decodeFun, substrateFun):
+    def indefLenValueDecoder(self, substrate, asn1Spec,
+                             tagSet=None, length=None, state=None,
+                             decodeFun=None, substrateFun=None,
+                             **options):
         if substrateFun:
             return substrateFun(
                 self._createComponent(asn1Spec, tagSet, ''),
                 substrate, length
             )
-        value, substrate = decodeFun(substrate, asn1Spec, tagSet, length)
-        terminator, substrate = decodeFun(substrate, allowEoo=True)
-        if terminator is eoo.endOfOctets:
+
+        value, substrate = decodeFun(substrate, asn1Spec, tagSet, length, **options)
+
+        eooMarker, substrate = decodeFun(substrate, allowEoo=True, **options)
+
+        if eooMarker is eoo.endOfOctets:
             return value, substrate
         else:
             raise error.PyAsn1Error('Missing end-of-octets terminator')
@@ -76,8 +90,10 @@ explicitTagDecoder = ExplicitTagDecoder()
 class IntegerDecoder(AbstractSimpleDecoder):
     protoComponent = univ.Integer(0)
 
-    def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet, length,
-                     state, decodeFun, substrateFun):
+    def valueDecoder(self, substrate, asn1Spec,
+                     tagSet=None, length=None, state=None,
+                     decodeFun=None, substrateFun=None,
+                     **options):
 
         if tagSet[0].tagFormat != tag.tagFormatSimple:
             raise error.PyAsn1Error('Simple tag format expected')
@@ -103,8 +119,10 @@ class BitStringDecoder(AbstractSimpleDecoder):
     protoComponent = univ.BitString(())
     supportConstructedForm = True
 
-    def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet, length,
-                     state, decodeFun, substrateFun):
+    def valueDecoder(self, substrate, asn1Spec,
+                     tagSet=None, length=None, state=None,
+                     decodeFun=None, substrateFun=None,
+                     **options):
         head, tail = substrate[:length], substrate[length:]
         if tagSet[0].tagFormat == tag.tagFormatSimple:  # XXX what tag to check?
             if not head:
@@ -127,20 +145,23 @@ class BitStringDecoder(AbstractSimpleDecoder):
             return substrateFun(bitString, substrate, length)
 
         while head:
-            component, head = decodeFun(head, self.protoComponent)
+            component, head = decodeFun(head, self.protoComponent, **options)
             bitString += component
 
         return bitString, tail
 
-    def indefLenValueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                             length, state, decodeFun, substrateFun):
+    def indefLenValueDecoder(self, substrate, asn1Spec,
+                             tagSet=None, length=None, state=None,
+                             decodeFun=None, substrateFun=None,
+                             **options):
         bitString = self._createComponent(asn1Spec, tagSet)
 
         if substrateFun:
             return substrateFun(bitString, substrate, length)
 
         while substrate:
-            component, substrate = decodeFun(substrate, self.protoComponent, allowEoo=True)
+            component, substrate = decodeFun(substrate, self.protoComponent,
+                                             allowEoo=True, **options)
             if component is eoo.endOfOctets:
                 break
 
@@ -156,8 +177,10 @@ class OctetStringDecoder(AbstractSimpleDecoder):
     protoComponent = univ.OctetString('')
     supportConstructedForm = True
 
-    def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet, length,
-                     state, decodeFun, substrateFun):
+    def valueDecoder(self, substrate, asn1Spec,
+                     tagSet=None, length=None, state=None,
+                     decodeFun=None, substrateFun=None,
+                     **options):
         head, tail = substrate[:length], substrate[length:]
 
         if substrateFun:
@@ -177,13 +200,16 @@ class OctetStringDecoder(AbstractSimpleDecoder):
 
         while head:
             component, head = decodeFun(head, self.protoComponent,
-                                        substrateFun=substrateFun)
+                                        substrateFun=substrateFun,
+                                        **options)
             header += component
 
         return self._createComponent(asn1Spec, tagSet, header), tail
 
-    def indefLenValueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                             length, state, decodeFun, substrateFun):
+    def indefLenValueDecoder(self, substrate, asn1Spec,
+                             tagSet=None, length=None, state=None,
+                             decodeFun=None, substrateFun=None,
+                             **options):
         if substrateFun and substrateFun is not self.substrateCollector:
             asn1Object = self._createComponent(asn1Spec, tagSet)
             return substrateFun(asn1Object, substrate, length)
@@ -197,7 +223,7 @@ class OctetStringDecoder(AbstractSimpleDecoder):
             component, substrate = decodeFun(substrate,
                                              self.protoComponent,
                                              substrateFun=substrateFun,
-                                             allowEoo=True)
+                                             allowEoo=True, **options)
             if component is eoo.endOfOctets:
                 break
             header += component
@@ -205,14 +231,17 @@ class OctetStringDecoder(AbstractSimpleDecoder):
             raise error.SubstrateUnderrunError(
                 'No EOO seen before substrate ends'
             )
+
         return self._createComponent(asn1Spec, tagSet, header), substrate
 
 
 class NullDecoder(AbstractSimpleDecoder):
     protoComponent = univ.Null('')
 
-    def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                     length, state, decodeFun, substrateFun):
+    def valueDecoder(self, substrate, asn1Spec,
+                     tagSet=None, length=None, state=None,
+                     decodeFun=None, substrateFun=None,
+                     **options):
 
         if tagSet[0].tagFormat != tag.tagFormatSimple:
             raise error.PyAsn1Error('Simple tag format expected')
@@ -230,9 +259,10 @@ class NullDecoder(AbstractSimpleDecoder):
 class ObjectIdentifierDecoder(AbstractSimpleDecoder):
     protoComponent = univ.ObjectIdentifier(())
 
-    def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet, length,
-                     state, decodeFun, substrateFun):
-
+    def valueDecoder(self, substrate, asn1Spec,
+                     tagSet=None, length=None, state=None,
+                     decodeFun=None, substrateFun=None,
+                     **options):
         if tagSet[0].tagFormat != tag.tagFormatSimple:
             raise error.PyAsn1Error('Simple tag format expected')
 
@@ -286,8 +316,10 @@ class ObjectIdentifierDecoder(AbstractSimpleDecoder):
 class RealDecoder(AbstractSimpleDecoder):
     protoComponent = univ.Real()
 
-    def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                     length, state, decodeFun, substrateFun):
+    def valueDecoder(self, substrate, asn1Spec,
+                     tagSet=None, length=None, state=None,
+                     decodeFun=None, substrateFun=None,
+                     **options):
         if tagSet[0].tagFormat != tag.tagFormatSimple:
             raise error.PyAsn1Error('Simple tag format expected')
 
@@ -371,11 +403,11 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
     def _getComponentPositionByType(self, asn1Object, tagSet, idx):
         raise NotImplementedError()
 
-    def _decodeComponents(self, substrate, decodeFun, tagSet, allowEoo=True):
+    def _decodeComponents(self, substrate, tagSet=None, decodeFun=None, **options):
         components = []
         componentTypes = set()
         while substrate:
-            component, substrate = decodeFun(substrate, allowEoo=True)
+            component, substrate = decodeFun(substrate, **options)
             if component is eoo.endOfOctets:
                 break
             components.append(component)
@@ -406,8 +438,10 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
 
         return asn1Object, substrate
 
-    def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                     length, state, decodeFun, substrateFun):
+    def valueDecoder(self, substrate, asn1Spec,
+                     tagSet=None, length=None, state=None,
+                     decodeFun=None, substrateFun=None,
+                     **options):
         if tagSet[0].tagFormat != tag.tagFormatConstructed:
             raise error.PyAsn1Error('Constructed tag format expected')
 
@@ -424,7 +458,9 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
             return substrateFun(asn1Object, substrate, length)
 
         if asn1Spec is None:
-            asn1Object, trailing = self._decodeComponents(head, decodeFun, tagSet)
+            asn1Object, trailing = self._decodeComponents(
+                head, tagSet=tagSet, decodeFun=decodeFun, **options
+            )
             if trailing:
                 raise error.PyAsn1Error('Unused trailing %d octets encountered' % len(trailing))
             return asn1Object, tail
@@ -455,10 +491,10 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
                             asn1Spec = namedTypes[idx].asn1Object
                     except IndexError:
                         raise error.PyAsn1Error(
-                            'Excessive components decoded at %r'(asn1Object,)
+                            'Excessive components decoded at %r' % (asn1Object,)
                         )
 
-                component, head = decodeFun(head, asn1Spec)
+                component, head = decodeFun(head, asn1Spec, **options)
 
                 if not isDeterministic and namedTypes:
                     if isSetType:
@@ -485,7 +521,7 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
             asn1Spec = asn1Object.componentType
             idx = 0
             while head:
-                component, head = decodeFun(head, asn1Spec)
+                component, head = decodeFun(head, asn1Spec, **options)
                 asn1Object.setComponentByPosition(
                     idx, component,
                     verifyConstraints=False,
@@ -497,8 +533,10 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
 
         return asn1Object, tail
 
-    def indefLenValueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                             length, state, decodeFun, substrateFun):
+    def indefLenValueDecoder(self, substrate, asn1Spec,
+                             tagSet=None, length=None, state=None,
+                             decodeFun=None, substrateFun=None,
+                             **options):
         if tagSet[0].tagFormat != tag.tagFormatConstructed:
             raise error.PyAsn1Error('Constructed tag format expected')
 
@@ -513,7 +551,9 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
             return substrateFun(asn1Object, substrate, length)
 
         if asn1Spec is None:
-            return self._decodeComponents(substrate, decodeFun, tagSet, allowEoo=True)
+            return self._decodeComponents(
+                substrate, tagSet=tagSet, decodeFun=decodeFun, allowEoo=True, **options
+            )
 
         asn1Object = asn1Spec.clone()
 
@@ -544,7 +584,7 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
                             'Excessive components decoded at %r' % (asn1Object,)
                         )
 
-                component, substrate = decodeFun(substrate, asn1Spec, allowEoo=True)
+                component, substrate = decodeFun(substrate, asn1Spec, allowEoo=True, **options)
                 if component is eoo.endOfOctets:
                     break
 
@@ -578,7 +618,7 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
             asn1Spec = asn1Object.componentType
             idx = 0
             while substrate:
-                component, substrate = decodeFun(substrate, asn1Spec, allowEoo=True)
+                component, substrate = decodeFun(substrate, asn1Spec, allowEoo=True, **options)
                 if component is eoo.endOfOctets:
                     break
                 asn1Object.setComponentByPosition(
@@ -625,8 +665,10 @@ class SetOfDecoder(SetOrSetOfDecoder):
 class ChoiceDecoder(AbstractConstructedDecoder):
     protoComponent = univ.Choice()
 
-    def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                     length, state, decodeFun, substrateFun):
+    def valueDecoder(self, substrate, asn1Spec,
+                     tagSet=None, length=None, state=None,
+                     decodeFun=None, substrateFun=None,
+                     **options):
         head, tail = substrate[:length], substrate[length:]
         if asn1Spec is None:
             asn1Object = self.protoComponent.clone(tagSet=tagSet)
@@ -636,11 +678,12 @@ class ChoiceDecoder(AbstractConstructedDecoder):
             return substrateFun(asn1Object, substrate, length)
         if asn1Object.tagSet == tagSet:  # explicitly tagged Choice
             component, head = decodeFun(
-                head, asn1Object.componentTagMap
+                head, asn1Object.componentTagMap, **options
             )
         else:
             component, head = decodeFun(
-                head, asn1Object.componentTagMap, tagSet, length, state
+                head, asn1Object.componentTagMap,
+                tagSet, length, state, **options
             )
         effectiveTagSet = component.effectiveTagSet
         asn1Object.setComponentByType(
@@ -651,8 +694,10 @@ class ChoiceDecoder(AbstractConstructedDecoder):
         )
         return asn1Object, tail
 
-    def indefLenValueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                             length, state, decodeFun, substrateFun):
+    def indefLenValueDecoder(self, substrate, asn1Spec,
+                             tagSet=None, length=None, state=None,
+                             decodeFun=None, substrateFun=None,
+                             **options):
         if asn1Spec is None:
             asn1Object = self.protoComponent.clone(tagSet=tagSet)
         else:
@@ -660,14 +705,19 @@ class ChoiceDecoder(AbstractConstructedDecoder):
         if substrateFun:
             return substrateFun(asn1Object, substrate, length)
         if asn1Object.tagSet == tagSet:  # explicitly tagged Choice
-            component, substrate = decodeFun(substrate, asn1Object.componentType.tagMapUnique)
+            component, substrate = decodeFun(
+                substrate, asn1Object.componentType.tagMapUnique, **options
+            )
             # eat up EOO marker
-            eooMarker, substrate = decodeFun(substrate, allowEoo=True)
+            eooMarker, substrate = decodeFun(
+                substrate, allowEoo=True, **options
+            )
             if eooMarker is not eoo.endOfOctets:
                 raise error.PyAsn1Error('No EOO seen before substrate ends')
         else:
             component, substrate = decodeFun(
-                substrate, asn1Object.componentType.tagMapUnique, tagSet, length, state
+                substrate, asn1Object.componentType.tagMapUnique,
+                tagSet, length, state, **options
             )
         effectiveTagSet = component.effectiveTagSet
         asn1Object.setComponentByType(
@@ -682,24 +732,35 @@ class ChoiceDecoder(AbstractConstructedDecoder):
 class AnyDecoder(AbstractSimpleDecoder):
     protoComponent = univ.Any()
 
-    def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                     length, state, decodeFun, substrateFun):
+    def valueDecoder(self, substrate, asn1Spec,
+                     tagSet=None, length=None, state=None,
+                     decodeFun=None, substrateFun=None,
+                     **options):
         if asn1Spec is None or asn1Spec is not None and tagSet != asn1Spec.tagSet:
+            fullSubstrate=options['fullSubstrate']
+
             # untagged Any container, recover inner header substrate
             length += len(fullSubstrate) - len(substrate)
             substrate = fullSubstrate
+
         if substrateFun:
             return substrateFun(self._createComponent(asn1Spec, tagSet),
                                 substrate, length)
+
         head, tail = substrate[:length], substrate[length:]
+
         return self._createComponent(asn1Spec, tagSet, value=head), tail
 
-    def indefLenValueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
-                             length, state, decodeFun, substrateFun):
+    def indefLenValueDecoder(self, substrate, asn1Spec,
+                             tagSet=None, length=None, state=None,
+                             decodeFun=None, substrateFun=None,
+                             **options):
         if asn1Spec is not None and tagSet == asn1Spec.tagSet:
             # tagged Any type -- consume header substrate
             header = null
         else:
+            fullSubstrate=options['fullSubstrate']
+
             # untagged Any, recover header substrate
             header = fullSubstrate[:-len(substrate)]
 
@@ -716,7 +777,7 @@ class AnyDecoder(AbstractSimpleDecoder):
         while substrate:
             component, substrate = decodeFun(substrate, asn1Spec,
                                              substrateFun=substrateFun,
-                                             allowEoo=True)
+                                             allowEoo=True, **options)
             if component is eoo.endOfOctets:
                 break
             header += component
@@ -863,9 +924,11 @@ class Decoder(object):
         self.__tagSetCache = {}
         self.__eooSentinel = ints2octs((0, 0))
 
-    def __call__(self, substrate, asn1Spec=None, tagSet=None,
-                 length=None, state=stDecodeTag, recursiveFlag=True,
-                 substrateFun=None, allowEoo=False):
+    def __call__(self, substrate, asn1Spec=None,
+                 tagSet=None, length=None, state=stDecodeTag,
+                 decodeFun=None, substrateFun=None,
+                 **options):
+
         if debug.logger & debug.flagDecoder:
             logger = debug.logger
         else:
@@ -873,6 +936,8 @@ class Decoder(object):
 
         if logger:
             logger('decoder called at scope %s with state %d, working with up to %d octets of substrate: %s' % (debug.scope, state, len(substrate), debug.hexdump(substrate)))
+
+        allowEoo = options.pop('allowEoo', False)
 
         # Look for end-of-octets sentinel
         if allowEoo and self.supportIndefLength:
@@ -1074,19 +1139,24 @@ class Decoder(object):
                     logger('codec %s chosen by ASN.1 spec, decoding %s' % (state is stDecodeValue and concreteDecoder.__class__.__name__ or "<none>", state is stDecodeValue and 'value' or 'as explicit tag'))
                     debug.scope.push(chosenSpec is None and '?' or chosenSpec.__class__.__name__)
             if state is stDecodeValue:
-                if not recursiveFlag and not substrateFun:  # deprecate this
-                    def substrateFun(a, b, c):
-                        return a, b[:c]
+                if not options.get('recursiveFlag', True) and not substrateFun:  # deprecate this
+                    substrateFun = lambda a, b, c: (a, b[:c])
+
+                options.update(fullSubstrate=fullSubstrate)
 
                 if length == -1:  # indef length
                     value, substrate = concreteDecoder.indefLenValueDecoder(
-                        fullSubstrate, substrate, asn1Spec, tagSet, length,
-                        stGetValueDecoder, self, substrateFun
+                        substrate, asn1Spec,
+                        tagSet, length, stGetValueDecoder,
+                        self, substrateFun,
+                        **options
                     )
                 else:
                     value, substrate = concreteDecoder.valueDecoder(
-                        fullSubstrate, substrate, asn1Spec, tagSet, length,
-                        stGetValueDecoder, self, substrateFun
+                        substrate, asn1Spec,
+                        tagSet, length, stGetValueDecoder,
+                        self, substrateFun,
+                        **options
                     )
                 if logger:
                     logger('codec %s yields type %s, value:\n%s\n...remaining substrate is: %s' % (concreteDecoder.__class__.__name__, value.__class__.__name__, value.prettyPrint(), substrate and debug.hexdump(substrate) or '<none>'))

--- a/pyasn1/codec/cer/decoder.py
+++ b/pyasn1/codec/cer/decoder.py
@@ -15,8 +15,10 @@ __all__ = ['decode']
 class BooleanDecoder(decoder.AbstractSimpleDecoder):
     protoComponent = univ.Boolean(0)
 
-    def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet, length,
-                     state, decodeFun, substrateFun):
+    def valueDecoder(self, substrate, asn1Spec,
+                     tagSet=None, length=None, state=None,
+                     decodeFun=None, substrateFun=None,
+                     **options):
         head, tail = substrate[:length], substrate[length:]
         if not head or length != 1:
             raise error.PyAsn1Error('Not single-octet Boolean payload')

--- a/pyasn1/codec/der/encoder.py
+++ b/pyasn1/codec/der/encoder.py
@@ -6,21 +6,20 @@
 #
 from pyasn1.type import univ
 from pyasn1.codec.cer import encoder
-from pyasn1 import error
 
 __all__ = ['encode']
 
 
 class BitStringEncoder(encoder.BitStringEncoder):
-    def encodeValue(self, encodeFun, value, defMode, maxChunkSize, ifNotEmpty=False):
+    def encodeValue(self, value, encodeFun, **options):
         return encoder.BitStringEncoder.encodeValue(
-            self, encodeFun, value, defMode, 0, ifNotEmpty=ifNotEmpty
+            self, value, encodeFun, **options
         )
 
 class OctetStringEncoder(encoder.OctetStringEncoder):
-    def encodeValue(self, encodeFun, value, defMode, maxChunkSize, ifNotEmpty=False):
+    def encodeValue(self, value, encodeFun, **options):
         return encoder.OctetStringEncoder.encodeValue(
-            self, encodeFun, value, defMode, 0, ifNotEmpty=ifNotEmpty
+            self, value, encodeFun, **options
         )
 
 class SetOfEncoder(encoder.SetOfEncoder):
@@ -50,10 +49,10 @@ typeMap.update({
 class Encoder(encoder.Encoder):
     supportIndefLength = False
 
-    def __call__(self, value, defMode=True, maxChunkSize=0, ifNotEmpty=False):
-        if not defMode:
-            raise error.PyAsn1Error('DER forbids indefinite length mode')
-        return encoder.Encoder.__call__(self, value, defMode, maxChunkSize, ifNotEmpty=ifNotEmpty)
+    def __call__(self, value, **options):
+        if 'defMode' not in options:
+            options.update(defMode=True)
+        return encoder.Encoder.__call__(self, value, **options)
 
 #: Turns ASN.1 object into DER octet stream.
 #:

--- a/pyasn1/codec/native/decoder.py
+++ b/pyasn1/codec/native/decoder.py
@@ -11,47 +11,47 @@ __all__ = ['decode']
 
 
 class AbstractScalarDecoder(object):
-    def __call__(self, pyObject, asn1Spec, decoderFunc=None):
+    def __call__(self, pyObject, asn1Spec, decodeFun=None, **options):
         return asn1Spec.clone(pyObject)
 
 
 class BitStringDecoder(AbstractScalarDecoder):
-    def __call__(self, pyObject, asn1Spec, decoderFunc=None):
+    def __call__(self, pyObject, asn1Spec, decodeFun=None, **options):
         return asn1Spec.clone(univ.BitString.fromBinaryString(pyObject))
 
 
 class SequenceOrSetDecoder(object):
-    def __call__(self, pyObject, asn1Spec, decoderFunc):
+    def __call__(self, pyObject, asn1Spec, decodeFun=None, **options):
         asn1Value = asn1Spec.clone()
 
         componentsTypes = asn1Spec.componentType
 
         for field in asn1Value:
             if field in pyObject:
-                asn1Value[field] = decoderFunc(pyObject[field], componentsTypes[field].asn1Object)
+                asn1Value[field] = decodeFun(pyObject[field], componentsTypes[field].asn1Object, **options)
 
         return asn1Value
 
 
 class SequenceOfOrSetOfDecoder(object):
-    def __call__(self, pyObject, asn1Spec, decoderFunc):
+    def __call__(self, pyObject, asn1Spec, decodeFun=None, **options):
         asn1Value = asn1Spec.clone()
 
         for pyValue in pyObject:
-            asn1Value.append(decoderFunc(pyValue, asn1Spec.componentType.asn1Object))
+            asn1Value.append(decodeFun(pyValue, asn1Spec.componentType.asn1Object), **options)
 
         return asn1Value
 
 
 class ChoiceDecoder(object):
-    def __call__(self, pyObject, asn1Spec, decoderFunc):
+    def __call__(self, pyObject, asn1Spec, decodeFun=None, **options):
         asn1Value = asn1Spec.clone()
 
         componentsTypes = asn1Spec.componentType
 
         for field in pyObject:
             if field in componentsTypes:
-                asn1Value[field] = decoderFunc(pyObject[field], componentsTypes[field].asn1Object)
+                asn1Value[field] = decodeFun(pyObject[field], componentsTypes[field].asn1Object, **options)
                 break
 
         return asn1Value
@@ -130,7 +130,7 @@ class Decoder(object):
         self.__tagMap = tagMap
         self.__typeMap = typeMap
 
-    def __call__(self, pyObject, asn1Spec):
+    def __call__(self, pyObject, asn1Spec, **options):
         if debug.logger & debug.flagDecoder:
             logger = debug.logger
         else:
@@ -144,9 +144,11 @@ class Decoder(object):
 
         try:
             valueDecoder = self.__typeMap[asn1Spec.typeId]
+
         except KeyError:
             # use base type for codec lookup to recover untagged types
             baseTagSet = tag.TagSet(asn1Spec.tagSet.baseTag, asn1Spec.tagSet.baseTag)
+
             try:
                 valueDecoder = self.__tagMap[baseTagSet]
             except KeyError:
@@ -155,7 +157,7 @@ class Decoder(object):
         if logger:
             logger('calling decoder %s on Python type %s <%s>' % (type(valueDecoder).__name__, type(pyObject).__name__, repr(pyObject)))
 
-        value = valueDecoder(pyObject, asn1Spec, self)
+        value = valueDecoder(pyObject, asn1Spec, self, **options)
 
         if logger:
             logger('decoder %s produced ASN.1 type %s <%s>' % (type(valueDecoder).__name__, type(value).__name__, repr(value)))

--- a/pyasn1/codec/native/encoder.py
+++ b/pyasn1/codec/native/encoder.py
@@ -17,72 +17,76 @@ __all__ = ['encode']
 
 
 class AbstractItemEncoder(object):
-    def encode(self, encodeFun, value):
+    def encode(self, value, encodeFun, **options):
         raise error.PyAsn1Error('Not implemented')
 
 
 class ExplicitlyTaggedItemEncoder(AbstractItemEncoder):
-    def encode(self, encodeFun, value):
+    def encode(self, value, encodeFun, **options):
         if isinstance(value, base.AbstractConstructedAsn1Item):
             value = value.clone(tagSet=value.tagSet[:-1],
                                 cloneValueFlag=1)
         else:
             value = value.clone(tagSet=value.tagSet[:-1])
-        return encodeFun(value)
+
+        return encodeFun(value, **options)
 
 explicitlyTaggedItemEncoder = ExplicitlyTaggedItemEncoder()
 
 
 class BooleanEncoder(AbstractItemEncoder):
-    def encode(self, encodeFun, value):
+    def encode(self, value, encodeFun, **options):
         return bool(value)
 
 
 class IntegerEncoder(AbstractItemEncoder):
-    def encode(self, encodeFun, value):
+    def encode(self, value, encodeFun, **options):
         return int(value)
 
 
 class BitStringEncoder(AbstractItemEncoder):
-    def encode(self, encodeFun, value):
+    def encode(self, value, encodeFun, **options):
         return str(value)
 
 
 class OctetStringEncoder(AbstractItemEncoder):
-    def encode(self, encodeFun, value):
+    def encode(self, value, encodeFun, **options):
         return value.asOctets()
 
 
 class TextStringEncoder(AbstractItemEncoder):
-    def encode(self, encodeFun, value):
+    def encode(self, value, encodeFun, **options):
         return value.prettyPrint()
 
 
 class NullEncoder(AbstractItemEncoder):
-    def encode(self, encodeFun, value):
+    def encode(self, value, encodeFun, **options):
         return None
 
 
 class ObjectIdentifierEncoder(AbstractItemEncoder):
-    def encode(self, encodeFun, value):
+    def encode(self, value, encodeFun, **options):
         return str(value)
 
 
 class RealEncoder(AbstractItemEncoder):
-    def encode(self, encodeFun, value):
+    def encode(self, value, encodeFun, **options):
         return float(value)
 
 
 class SetEncoder(AbstractItemEncoder):
     protoDict = dict
-    def encode(self, encodeFun, value):
+
+    def encode(self, value, encodeFun, **options):
         value.verifySizeSpec()
+
         namedTypes = value.componentType
         substrate = self.protoDict()
+
         for idx, (key, subValue) in enumerate(value.items()):
             if namedTypes and namedTypes[idx].isOptional and not value[idx].isValue:
                 continue
-            substrate[key] = encodeFun(subValue)
+            substrate[key] = encodeFun(subValue, **options)
         return substrate
 
 
@@ -91,9 +95,9 @@ class SequenceEncoder(SetEncoder):
 
 
 class SequenceOfEncoder(AbstractItemEncoder):
-    def encode(self, encodeFun, value):
+    def encode(self, value, encodeFun, **options):
         value.verifySizeSpec()
-        return [encodeFun(x) for x in value]
+        return [encodeFun(x, **options) for x in value]
 
 
 class ChoiceEncoder(SequenceEncoder):
@@ -101,7 +105,7 @@ class ChoiceEncoder(SequenceEncoder):
 
 
 class AnyEncoder(AbstractItemEncoder):
-    def encode(self, encodeFun, value):
+    def encode(self, value, encodeFun, **options):
         return value.asOctets()
 
 
@@ -154,7 +158,7 @@ class Encoder(object):
         self.__tagMap = tagMap
         self.__typeMap = typeMap
 
-    def __call__(self, asn1Value):
+    def __call__(self, asn1Value, **options):
         if not isinstance(asn1Value, base.Asn1Item):
             raise error.PyAsn1Error('value is not valid (should be an instance of an ASN.1 Item)')
 
@@ -184,7 +188,7 @@ class Encoder(object):
         if logger:
             logger('using value codec %s chosen by %s' % (type(concreteEncoder).__name__, tagSet))
 
-        pyObject = concreteEncoder.encode(self, asn1Value)
+        pyObject = concreteEncoder.encode(asn1Value, self, **options)
 
         if logger:
             logger('encoder %s produced: %s' % (type(concreteEncoder).__name__, repr(pyObject)))


### PR DESCRIPTION
This change introduces more common API to various codecs and allows passing opaque options to the codecs through the whole call chain.

WARNING: signatures of some undocumented codecs methods changed