### PR TITLE
Efficient explicit tags encoding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Revision 0.3.5, released XX-09-2017
 -----------------------------------
 
 - Codecs signatures unified and pass **options through the call chain
+- Explicit tag encoding optimized to avoid unnecessary copying
 
 Revision 0.3.4, released 07-09-2017
 -----------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Revision 0.3.5, released XX-09-2017
 
 - Codecs signatures unified and pass **options through the call chain
 - Explicit tag encoding optimized to avoid unnecessary copying
+- End-of-octets sentinel encoding optimized
 
 Revision 0.3.4, released 07-09-2017
 -----------------------------------

--- a/pyasn1/codec/ber/encoder.py
+++ b/pyasn1/codec/ber/encoder.py
@@ -50,12 +50,6 @@ class AbstractItemEncoder(object):
     def encodeValue(self, value, encodeFun, **options):
         raise error.PyAsn1Error('Not implemented')
 
-    def _encodeEndOfOctets(self, encodeFun, defMode):
-        if defMode or not self.supportIndefLenMode:
-            return null
-        else:
-            return encodeFun(eoo.endOfOctets, defMode=defMode)
-
     def encode(self, value, encodeFun, **options):
 
         tagSet = value.tagSet
@@ -94,9 +88,8 @@ class AbstractItemEncoder(object):
             else:
                 substrate = ints2octs(header + substrate)
 
-            eoo =  self._encodeEndOfOctets(encodeFun, defModeOverride)
-            if eoo:
-                substrate += eoo
+            if not defModeOverride:
+                substrate += encodeFun(eoo.endOfOctets, defMode=defModeOverride)
 
         return substrate
 

--- a/tests/codec/ber/test_encoder.py
+++ b/tests/codec/ber/test_encoder.py
@@ -142,8 +142,7 @@ class ExpTaggedOctetStringEncoderTestCase(unittest.TestCase):
     def testIndefModeChunked(self):
         assert encoder.encode(
             self.o, defMode=False, maxChunkSize=4
-        ) == ints2octs((101, 128, 36, 128, 4, 4, 81, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 4, 111, 119, 110, 32, 4, 3,
-                        102, 111, 120, 0, 0, 0, 0))
+        ) == ints2octs((101, 128, 36, 128, 4, 4, 81, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 4, 111, 119, 110, 32, 4, 3, 102, 111, 120, 0, 0, 0, 0))
 
 
 class NullEncoderTestCase(unittest.TestCase):
@@ -616,6 +615,31 @@ class SequenceEncoderWithSchemaTestCase(unittest.TestCase):
             self.s, defMode=False, maxChunkSize=4
         ) == ints2octs((48, 128, 5, 0, 36, 128, 4, 4, 113, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 3, 111, 119, 110, 0,
                         0, 2, 1, 1, 0, 0))
+
+
+class ExpTaggedSequenceEncoderTestCase(unittest.TestCase):
+    def setUp(self):
+        s = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('number', univ.Integer()),
+            )
+        )
+
+        s = s.subtype(
+            explicitTag=tag.Tag(tag.tagClassApplication, tag.tagFormatConstructed, 5)
+        )
+
+        s[0] = 12
+
+        self.s = s
+
+    def testDefMode(self):
+        assert encoder.encode(self.s) == ints2octs((101, 5, 48, 3, 2, 1, 12))
+
+    def testIndefMode(self):
+        assert encoder.encode(
+            self.s, defMode=False
+        ) == ints2octs((101, 128, 48, 128, 2, 1, 12, 0, 0, 0, 0))
 
 
 class SetEncoderTestCase(unittest.TestCase):


### PR DESCRIPTION
This change fixes a huge inefficiency in how ASN.1 EXPLICIT tags used to be encoded. The codec used to encode tags one-by-one what involved deep-copying the value being encoded.

The reworked algorithm just iterates over tags appending the prepending the encoded blobs at the head of the octet string.