### PR TITLE
Run unit tests with full debugging enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Revision 0.3.5, released XX-09-2017
   chunk size encoding modes
 - Fixed DER encoder to always produce primitive encoding
 - Fixed crash at SequenceOf native decoder
+- Fixed Real.prettyPrint() to fail gracefully on overflow
+- Fixed a couple of crashes when debug mode is enabled
 
 Revision 0.3.4, released 07-09-2017
 -----------------------------------

--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -1160,7 +1160,7 @@ class Decoder(object):
                         **options
                     )
                 if logger:
-                    logger('codec %s yields type %s, value:\n%s\n...remaining substrate is: %s' % (concreteDecoder.__class__.__name__, value.__class__.__name__, value.prettyPrint(), substrate and debug.hexdump(substrate) or '<none>'))
+                    logger('codec %s yields type %s, value:\n%s\n...remaining substrate is: %s' % (concreteDecoder.__class__.__name__, value.__class__.__name__, isinstance(value, base.Asn1Item) and value.prettyPrint() or value, substrate and debug.hexdump(substrate) or '<none>'))
                 state = stStop
                 break
             if state is stTryAsExplicitTag:

--- a/pyasn1/codec/ber/encoder.py
+++ b/pyasn1/codec/ber/encoder.py
@@ -476,7 +476,7 @@ class Encoder(object):
             logger = None
 
         if logger:
-            logger('encoder called in %sdef mode, chunk size %s for type %s, value:\n%s' % (not defMode and 'in' or '', maxChunkSize, value.prettyPrintType(), value.prettyPrint()))
+            logger('encoder called in %sdef mode, chunk size %s for type %s, value:\n%s' % (not options.get('defMode', True) and 'in' or '', options.get('maxChunkSize', 0), value.prettyPrintType(), value.prettyPrint()))
 
         if self.fixedDefLengthMode is not None:
             options.update(defMode=self.fixedDefLengthMode)

--- a/pyasn1/debug.py
+++ b/pyasn1/debug.py
@@ -28,25 +28,31 @@ class Printer(object):
     def __init__(self, logger=None, handler=None, formatter=None):
         if logger is None:
             logger = logging.getLogger('pyasn1')
+
         logger.setLevel(logging.DEBUG)
+
         if handler is None:
             handler = logging.StreamHandler()
+
         if formatter is None:
             formatter = logging.Formatter('%(asctime)s %(name)s: %(message)s')
+
         handler.setFormatter(formatter)
         handler.setLevel(logging.DEBUG)
         logger.addHandler(handler)
+
         self.__logger = logger
 
     def __call__(self, msg):
         self.__logger.debug(msg)
 
     def __str__(self):
-        return '<python built-in logging>'
+        return '<python logging>'
 
 
 if hasattr(logging, 'NullHandler'):
     NullHandler = logging.NullHandler
+
 else:
     # Python 2.6 and older
     class NullHandler(logging.Handler):
@@ -55,36 +61,39 @@ else:
 
 
 class Debug(object):
-    defaultPrinter = None
+    defaultPrinter = Printer()
 
     def __init__(self, *flags, **options):
         self._flags = flagNone
-        if options.get('printer') is not None:
-            self._printer = options.get('printer')
-        elif self.defaultPrinter is not None:
-            self._printer = self.defaultPrinter
+
         if 'loggerName' in options:
             # route our logs to parent logger
             self._printer = Printer(
                 logger=logging.getLogger(options['loggerName']),
                 handler=NullHandler()
             )
+
+        elif 'printer' in options:
+            self._printer = options.get('printer')
+
         else:
-            self._printer = Printer()
-        self('running pyasn1 version %s' % __version__)
-        for f in flags:
-            inverse = f and f[0] in ('!', '~')
+            self._printer = self.defaultPrinter
+
+        self._printer('running pyasn1 %s, debug flags %s' % (__version__, ', '.join(flags)))
+
+        for flag in flags:
+            inverse = flag and flag[0] in ('!', '~')
             if inverse:
-                f = f[1:]
+                flag = flag[1:]
             try:
                 if inverse:
-                    self._flags &= ~flagMap[f]
+                    self._flags &= ~flagMap[flag]
                 else:
-                    self._flags |= flagMap[f]
+                    self._flags |= flagMap[flag]
             except KeyError:
-                raise error.PyAsn1Error('bad debug flag %s' % f)
+                raise error.PyAsn1Error('bad debug flag %s' % flag)
 
-            self('debug category \'%s\' %s' % (f, inverse and 'disabled' or 'enabled'))
+            self._printer("debug category '%s' %s" % (flag, inverse and 'disabled' or 'enabled'))
 
     def __str__(self):
         return 'logger %s, flags %x' % (self._printer, self._flags)
@@ -102,9 +111,13 @@ class Debug(object):
 logger = 0
 
 
-def setLogger(l):
+def setLogger(userLogger):
     global logger
-    logger = l
+
+    if userLogger:
+        logger = userLogger
+    else:
+        logger = 0
 
 
 def hexdump(octets):

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -1498,7 +1498,11 @@ class Real(base.AbstractSimpleAsn1Item):
         if self.isInf:
             return self.prettyOut(self._value)
         else:
-            return str(float(self))
+            try:
+                return str(float(self))
+
+            except OverflowError:
+                return '<overflow>'
 
     @property
     def isPlusInf(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,22 @@
+#
+# This file is part of pyasn1 software.
+#
+# Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+# License: http://pyasn1.sf.net/license.html
+#
+import sys
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from pyasn1 import debug
+
+
+class BaseTestCase(unittest.TestCase):
+
+    def setUp(self):
+        debug.setLogger(debug.Debug('all', printer=lambda *x: None))
+
+    def tearDown(self):
+        debug.setLogger(None)

--- a/tests/codec/ber/test_decoder.py
+++ b/tests/codec/ber/test_decoder.py
@@ -10,13 +10,15 @@ try:
 except ImportError:
     import unittest
 
+from tests.base import BaseTestCase
+
 from pyasn1.type import tag, namedtype, univ, char
 from pyasn1.codec.ber import decoder, eoo
 from pyasn1.compat.octets import ints2octs, str2octs, null
 from pyasn1.error import PyAsn1Error
 
 
-class LargeTagDecoderTestCase(unittest.TestCase):
+class LargeTagDecoderTestCase(BaseTestCase):
     def testLargeTag(self):
         assert decoder.decode(ints2octs((127, 141, 245, 182, 253, 47, 3, 2, 1, 1))) == (1, null)
 
@@ -29,12 +31,12 @@ class LargeTagDecoderTestCase(unittest.TestCase):
             ints2octs((0x9f, 0x00, 0x02, 0x01, 0x02)), asn1Spec=integer)
 
 
-class DecoderCacheTestCase(unittest.TestCase):
+class DecoderCacheTestCase(BaseTestCase):
     def testCache(self):
         assert decoder.decode(ints2octs((0x1f, 2, 1, 0))) == decoder.decode(ints2octs((0x1f, 2, 1, 0)))
 
 
-class IntegerDecoderTestCase(unittest.TestCase):
+class IntegerDecoderTestCase(BaseTestCase):
     def testPosInt(self):
         assert decoder.decode(ints2octs((2, 1, 12))) == (12, null)
 
@@ -82,7 +84,7 @@ class IntegerDecoderTestCase(unittest.TestCase):
             assert 0, 'wrong tagFormat worked out'
 
 
-class BooleanDecoderTestCase(unittest.TestCase):
+class BooleanDecoderTestCase(BaseTestCase):
     def testTrue(self):
         assert decoder.decode(ints2octs((1, 1, 1))) == (1, null)
 
@@ -104,7 +106,7 @@ class BooleanDecoderTestCase(unittest.TestCase):
             assert 0, 'wrong tagFormat worked out'
 
 
-class BitStringDecoderTestCase(unittest.TestCase):
+class BitStringDecoderTestCase(BaseTestCase):
     def testDefMode(self):
         assert decoder.decode(
             ints2octs((3, 3, 1, 169, 138))
@@ -128,14 +130,14 @@ class BitStringDecoderTestCase(unittest.TestCase):
     def testDefModeChunkedSubst(self):
         assert decoder.decode(
             ints2octs((35, 8, 3, 2, 0, 169, 3, 2, 1, 138)),
-            substrateFun=lambda a, b, c: (b, c)
-        ) == (ints2octs((3, 2, 0, 169, 3, 2, 1, 138)), 8)
+            substrateFun=lambda a, b, c: (b, b[c:])
+        ) == (ints2octs((3, 2, 0, 169, 3, 2, 1, 138)), str2octs(''))
 
     def testIndefModeChunkedSubst(self):
         assert decoder.decode(
             ints2octs((35, 128, 3, 2, 0, 169, 3, 2, 1, 138, 0, 0)),
-            substrateFun=lambda a, b, c: (b, c)
-        ) == (ints2octs((3, 2, 0, 169, 3, 2, 1, 138, 0, 0)), -1)
+            substrateFun=lambda a, b, c: (b, str2octs(''))
+        ) == (ints2octs((3, 2, 0, 169, 3, 2, 1, 138, 0, 0)), str2octs(''))
 
     def testTypeChecking(self):
         try:
@@ -146,7 +148,7 @@ class BitStringDecoderTestCase(unittest.TestCase):
             assert 0, 'accepted mis-encoded bit-string constructed out of an integer'
 
 
-class OctetStringDecoderTestCase(unittest.TestCase):
+class OctetStringDecoderTestCase(BaseTestCase):
     def testDefMode(self):
         assert decoder.decode(
             ints2octs((4, 15, 81, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120))
@@ -173,21 +175,21 @@ class OctetStringDecoderTestCase(unittest.TestCase):
         assert decoder.decode(
             ints2octs(
                 (36, 23, 4, 4, 81, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 4, 111, 119, 110, 32, 4, 3, 102, 111, 120)),
-            substrateFun=lambda a, b, c: (b, c)
-        ) == (ints2octs((4, 4, 81, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 4, 111, 119, 110, 32, 4, 3, 102, 111, 120)),
-              23)
+            substrateFun=lambda a, b, c: (b, b[c:])
+        ) == (ints2octs((4, 4, 81, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 4, 111, 119, 110, 32, 4, 3, 102, 111, 120)), str2octs(''))
 
     def testIndefModeChunkedSubst(self):
         assert decoder.decode(
             ints2octs((36, 128, 4, 4, 81, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 4, 111, 119, 110, 32, 4, 3, 102, 111,
                        120, 0, 0)),
-            substrateFun=lambda a, b, c: (b, c)
+            substrateFun=lambda a, b, c: (b, str2octs(''))
         ) == (ints2octs(
-            (4, 4, 81, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 4, 111, 119, 110, 32, 4, 3, 102, 111, 120, 0, 0)), -1)
+            (4, 4, 81, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 4, 111, 119, 110, 32, 4, 3, 102, 111, 120, 0, 0)), str2octs(''))
 
 
-class ExpTaggedOctetStringDecoderTestCase(unittest.TestCase):
+class ExpTaggedOctetStringDecoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.o = univ.OctetString(
             'Quick brown fox',
             tagSet=univ.OctetString.tagSet.tagExplicitly(
@@ -233,20 +235,20 @@ class ExpTaggedOctetStringDecoderTestCase(unittest.TestCase):
     def testDefModeSubst(self):
         assert decoder.decode(
             ints2octs((101, 17, 4, 15, 81, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120)),
-            substrateFun=lambda a, b, c: (b, c)
-        ) == (ints2octs((4, 15, 81, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120)), 17)
+            substrateFun=lambda a, b, c: (b, b[c:])
+        ) == (ints2octs((4, 15, 81, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120)), str2octs(''))
 
     def testIndefModeSubst(self):
         assert decoder.decode(
             ints2octs((
                       101, 128, 36, 128, 4, 15, 81, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 0,
                       0, 0, 0)),
-            substrateFun=lambda a, b, c: (b, c)
+            substrateFun=lambda a, b, c: (b, str2octs(''))
         ) == (ints2octs(
-            (36, 128, 4, 15, 81, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 0, 0, 0, 0)), -1)
+            (36, 128, 4, 15, 81, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 0, 0, 0, 0)), str2octs(''))
 
 
-class NullDecoderTestCase(unittest.TestCase):
+class NullDecoderTestCase(BaseTestCase):
     def testNull(self):
         assert decoder.decode(ints2octs((5, 0))) == (null, null)
 
@@ -261,7 +263,7 @@ class NullDecoderTestCase(unittest.TestCase):
 
 # Useful analysis of OID encoding issues could be found here:
 # http://www.viathinksoft.de/~daniel-marschall/asn.1/oid_facts.html
-class ObjectIdentifierDecoderTestCase(unittest.TestCase):
+class ObjectIdentifierDecoderTestCase(BaseTestCase):
     def testOne(self):
         assert decoder.decode(
             ints2octs((6, 6, 43, 6, 0, 191, 255, 126))
@@ -402,7 +404,7 @@ class ObjectIdentifierDecoderTestCase(unittest.TestCase):
         ) == ((2, 999, 18446744073709551535184467440737095), null)
 
 
-class RealDecoderTestCase(unittest.TestCase):
+class RealDecoderTestCase(BaseTestCase):
     def testChar(self):
         assert decoder.decode(
             ints2octs((9, 7, 3, 49, 50, 51, 69, 49, 49))
@@ -478,23 +480,25 @@ class RealDecoderTestCase(unittest.TestCase):
 
 
 if sys.version_info[0:2] > (2, 5):
-    class UniversalStringDecoderTestCase(unittest.TestCase):
+    class UniversalStringDecoderTestCase(BaseTestCase):
         def testDecoder(self):
             assert decoder.decode(ints2octs((28, 12, 0, 0, 0, 97, 0, 0, 0, 98, 0, 0, 0, 99))) == (char.UniversalString(sys.version_info[0] == 3 and 'abc' or unicode('abc')), null)
 
 
-class BMPStringDecoderTestCase(unittest.TestCase):
+class BMPStringDecoderTestCase(BaseTestCase):
     def testDecoder(self):
         assert decoder.decode(ints2octs((30, 6, 0, 97, 0, 98, 0, 99))) == (char.BMPString(sys.version_info[0] == 3 and 'abc' or unicode('abc')), null)
 
 
-class UTF8StringDecoderTestCase(unittest.TestCase):
+class UTF8StringDecoderTestCase(BaseTestCase):
     def testDecoder(self):
         assert decoder.decode(ints2octs((12, 3, 97, 98, 99))) == (char.UTF8String(sys.version_info[0] == 3 and 'abc' or unicode('abc')), null)
 
 
-class SequenceOfDecoderTestCase(unittest.TestCase):
+class SequenceOfDecoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         self.s = univ.SequenceOf(componentType=univ.OctetString())
         self.s.setComponentByPosition(0, univ.OctetString('quick brown'))
 
@@ -524,7 +528,7 @@ class SequenceOfDecoderTestCase(unittest.TestCase):
         ) == (self.s, null)
 
 
-class ExpTaggedSequenceOfDecoderTestCase(unittest.TestCase):
+class ExpTaggedSequenceOfDecoderTestCase(BaseTestCase):
 
     def testWithSchema(self):
         s = univ.SequenceOf().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 3))
@@ -545,8 +549,9 @@ class ExpTaggedSequenceOfDecoderTestCase(unittest.TestCase):
         assert s.tagSet == s2.tagSet
 
 
-class SequenceOfDecoderWithSchemaTestCase(unittest.TestCase):
+class SequenceOfDecoderWithSchemaTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.SequenceOf(componentType=univ.OctetString())
         self.s.setComponentByPosition(0, univ.OctetString('quick brown'))
 
@@ -571,8 +576,9 @@ class SequenceOfDecoderWithSchemaTestCase(unittest.TestCase):
         ) == (self.s, null)
 
 
-class SetOfDecoderTestCase(unittest.TestCase):
+class SetOfDecoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.SetOf(componentType=univ.OctetString())
         self.s.setComponentByPosition(0, univ.OctetString('quick brown'))
 
@@ -602,8 +608,9 @@ class SetOfDecoderTestCase(unittest.TestCase):
         ) == (self.s, null)
 
 
-class SetOfDecoderWithSchemaTestCase(unittest.TestCase):
+class SetOfDecoderWithSchemaTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.SetOf(componentType=univ.OctetString())
         self.s.setComponentByPosition(0, univ.OctetString('quick brown'))
 
@@ -628,8 +635,9 @@ class SetOfDecoderWithSchemaTestCase(unittest.TestCase):
         ) == (self.s, null)
 
 
-class SequenceDecoderTestCase(unittest.TestCase):
+class SequenceDecoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Sequence(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('place-holder', univ.Null(null)),
@@ -665,16 +673,15 @@ class SequenceDecoderTestCase(unittest.TestCase):
     def testWithOptionalAndDefaultedDefModeSubst(self):
         assert decoder.decode(
             ints2octs((48, 18, 5, 0, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 2, 1, 1)),
-            substrateFun=lambda a, b, c: (b, c)
-        ) == (ints2octs((5, 0, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 2, 1, 1)), 18)
+            substrateFun=lambda a, b, c: (b, b[c:])
+        ) == (ints2octs((5, 0, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 2, 1, 1)), str2octs(''))
 
     def testWithOptionalAndDefaultedIndefModeSubst(self):
         assert decoder.decode(
-            ints2octs((48, 128, 5, 0, 36, 128, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 0, 0, 2, 1, 1,
-                       0, 0)),
-            substrateFun=lambda a, b, c: (b, c)
+            ints2octs((48, 128, 5, 0, 36, 128, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 0, 0, 2, 1, 1, 0, 0)),
+            substrateFun=lambda a, b, c: (b, str2octs(''))
         ) == (ints2octs(
-            (5, 0, 36, 128, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 0, 0, 2, 1, 1, 0, 0)), -1)
+            (5, 0, 36, 128, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 0, 0, 2, 1, 1, 0, 0)), str2octs(''))
 
     def testTagFormat(self):
         try:
@@ -687,8 +694,9 @@ class SequenceDecoderTestCase(unittest.TestCase):
             assert 0, 'wrong tagFormat worked out'
 
 
-class SequenceDecoderWithSchemaTestCase(unittest.TestCase):
+class SequenceDecoderWithSchemaTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Sequence(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('place-holder', univ.Null(null)),
@@ -823,8 +831,9 @@ class SequenceDecoderWithSchemaTestCase(unittest.TestCase):
         ) == (self.s, null)
 
 
-class SetDecoderTestCase(unittest.TestCase):
+class SetDecoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Set(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('place-holder', univ.Null(null)),
@@ -860,15 +869,15 @@ class SetDecoderTestCase(unittest.TestCase):
     def testWithOptionalAndDefaultedDefModeSubst(self):
         assert decoder.decode(
             ints2octs((49, 18, 5, 0, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 2, 1, 1)),
-            substrateFun=lambda a, b, c: (b, c)
-        ) == (ints2octs((5, 0, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 2, 1, 1)), 18)
+            substrateFun=lambda a, b, c: (b, b[c:])
+        ) == (ints2octs((5, 0, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 2, 1, 1)), str2octs(''))
 
     def testWithOptionalAndDefaultedIndefModeSubst(self):
         assert decoder.decode(
             ints2octs((49, 128, 5, 0, 36, 128, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 0, 0, 2, 1, 1, 0, 0)),
-            substrateFun=lambda a, b, c: (b, c)
+            substrateFun=lambda a, b, c: (b, str2octs(''))
         ) == (ints2octs(
-            (5, 0, 36, 128, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 0, 0, 2, 1, 1, 0, 0)), -1)
+            (5, 0, 36, 128, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 0, 0, 2, 1, 1, 0, 0)), str2octs(''))
 
     def testTagFormat(self):
         try:
@@ -881,8 +890,9 @@ class SetDecoderTestCase(unittest.TestCase):
             assert 0, 'wrong tagFormat worked out'
 
 
-class SetDecoderWithSchemaTestCase(unittest.TestCase):
+class SetDecoderWithSchemaTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Set(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('place-holder', univ.Null(null)),
@@ -1020,8 +1030,9 @@ class SetDecoderWithSchemaTestCase(unittest.TestCase):
         ) == (self.s, null)
 
 
-class SequenceOfWithExpTaggedOctetStringDecoder(unittest.TestCase):
+class SequenceOfWithExpTaggedOctetStringDecoder(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.SequenceOf(
             componentType=univ.OctetString().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 3))
         )
@@ -1065,8 +1076,9 @@ class SequenceOfWithExpTaggedOctetStringDecoder(unittest.TestCase):
         assert s.tagSet == self.s.tagSet
 
 
-class SequenceWithExpTaggedOctetStringDecoder(unittest.TestCase):
+class SequenceWithExpTaggedOctetStringDecoder(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Sequence(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType(
@@ -1114,8 +1126,9 @@ class SequenceWithExpTaggedOctetStringDecoder(unittest.TestCase):
         assert s.tagSet == self.s.tagSet
 
 
-class ChoiceDecoderTestCase(unittest.TestCase):
+class ChoiceDecoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Choice(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('place-holder', univ.Null(null)),
@@ -1153,8 +1166,9 @@ class ChoiceDecoderTestCase(unittest.TestCase):
         assert decoder.decode(ints2octs((164, 128, 5, 0, 0, 0)), asn1Spec=s) == (s, null)
 
 
-class AnyDecoderTestCase(unittest.TestCase):
+class AnyDecoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Any()
 
     def testByUntagged(self):
@@ -1187,18 +1201,18 @@ class AnyDecoderTestCase(unittest.TestCase):
         assert decoder.decode(
             ints2octs((4, 3, 102, 111, 120)),
             asn1Spec=self.s,
-            substrateFun=lambda a, b, c: (b, c)
-        ) == (ints2octs((4, 3, 102, 111, 120)), 5)
+            substrateFun=lambda a, b, c: (b, b[c:])
+        ) == (ints2octs((4, 3, 102, 111, 120)), str2octs(''))
 
     def testTaggedExSubst(self):
         assert decoder.decode(
             ints2octs((164, 5, 4, 3, 102, 111, 120)),
             asn1Spec=self.s,
-            substrateFun=lambda a, b, c: (b, c)
-        ) == (ints2octs((164, 5, 4, 3, 102, 111, 120)), 7)
+            substrateFun=lambda a, b, c: (b, b[c:])
+        ) == (ints2octs((164, 5, 4, 3, 102, 111, 120)), str2octs(''))
 
 
-class EndOfOctetsTestCase(unittest.TestCase):
+class EndOfOctetsTestCase(BaseTestCase):
     def testUnexpectedEoo(self):
         try:
             decoder.decode(ints2octs((0, 0)))
@@ -1249,8 +1263,9 @@ class EndOfOctetsTestCase(unittest.TestCase):
             assert 0, 'end-of-contents octets accepted with unexpected data'
 
 
-class NonStringDecoderTestCase(unittest.TestCase):
+class NonStringDecoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Sequence(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('place-holder', univ.Null(null)),

--- a/tests/codec/ber/test_encoder.py
+++ b/tests/codec/ber/test_encoder.py
@@ -5,20 +5,25 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
+
 try:
     import unittest2 as unittest
+
 except ImportError:
     import unittest
+
+from tests.base import BaseTestCase
 
 from pyasn1.type import tag, namedtype, univ, char
 from pyasn1.codec.ber import encoder
 from pyasn1.compat.octets import ints2octs
 from pyasn1.error import PyAsn1Error
-from sys import version_info
 
 
 class LargeTagEncoderTestCase(unittest.TestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         self.o = univ.Integer().subtype(
             value=1, explicitTag=tag.Tag(tag.tagClassApplication, tag.tagFormatSimple, 0xdeadbeaf)
         )
@@ -27,7 +32,7 @@ class LargeTagEncoderTestCase(unittest.TestCase):
         assert encoder.encode(self.o) == ints2octs((127, 141, 245, 182, 253, 47, 3, 2, 1, 1))
 
 
-class IntegerEncoderTestCase(unittest.TestCase):
+class IntegerEncoderTestCase(BaseTestCase):
     def testPosInt(self):
         assert encoder.encode(univ.Integer(12)) == ints2octs((2, 1, 12))
 
@@ -57,7 +62,7 @@ class IntegerEncoderTestCase(unittest.TestCase):
         ) == ints2octs((2, 9, 255, 0, 0, 0, 0, 0, 0, 0, 1))
 
 
-class BooleanEncoderTestCase(unittest.TestCase):
+class BooleanEncoderTestCase(BaseTestCase):
     def testTrue(self):
         assert encoder.encode(univ.Boolean(1)) == ints2octs((1, 1, 1))
 
@@ -65,8 +70,9 @@ class BooleanEncoderTestCase(unittest.TestCase):
         assert encoder.encode(univ.Boolean(0)) == ints2octs((1, 1, 0))
 
 
-class BitStringEncoderTestCase(unittest.TestCase):
+class BitStringEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.b = univ.BitString((1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1))
 
     def testDefMode(self):
@@ -91,8 +97,9 @@ class BitStringEncoderTestCase(unittest.TestCase):
         assert encoder.encode(univ.BitString([])) == ints2octs((3, 1, 0))
 
 
-class OctetStringEncoderTestCase(unittest.TestCase):
+class OctetStringEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.o = univ.OctetString('Quick brown fox')
 
     def testDefMode(self):
@@ -117,8 +124,9 @@ class OctetStringEncoderTestCase(unittest.TestCase):
                         32, 4, 3, 102,  111, 120, 0, 0))
 
 
-class ExpTaggedOctetStringEncoderTestCase(unittest.TestCase):
+class ExpTaggedOctetStringEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.o = univ.OctetString().subtype(
             value='Quick brown fox',
             explicitTag=tag.Tag(tag.tagClassApplication, tag.tagFormatSimple, 5)
@@ -145,12 +153,12 @@ class ExpTaggedOctetStringEncoderTestCase(unittest.TestCase):
         ) == ints2octs((101, 128, 36, 128, 4, 4, 81, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 4, 111, 119, 110, 32, 4, 3, 102, 111, 120, 0, 0, 0, 0))
 
 
-class NullEncoderTestCase(unittest.TestCase):
+class NullEncoderTestCase(BaseTestCase):
     def testNull(self):
         assert encoder.encode(univ.Null('')) == ints2octs((5, 0))
 
 
-class ObjectIdentifierEncoderTestCase(unittest.TestCase):
+class ObjectIdentifierEncoderTestCase(BaseTestCase):
     def testOne(self):
         assert encoder.encode(
             univ.ObjectIdentifier((1, 3, 6, 0, 0xffffe))
@@ -258,7 +266,7 @@ class ObjectIdentifierEncoderTestCase(unittest.TestCase):
                         0xB8, 0xCB, 0xE2, 0xB6, 0x47))
 
 
-class RealEncoderTestCase(unittest.TestCase):
+class RealEncoderTestCase(BaseTestCase):
     def testChar(self):
         assert encoder.encode(
             univ.Real((123, 10, 11))
@@ -322,26 +330,26 @@ class RealEncoderTestCase(unittest.TestCase):
         assert encoder.encode(univ.Real(0)) == ints2octs((9, 0))
 
 
-if version_info[0:2] > (2, 5):
-    class UniversalStringEncoderTestCase(unittest.TestCase):
+if sys.version_info[0:2] > (2, 5):
+    class UniversalStringEncoderTestCase(BaseTestCase):
         def testEncoding(self):
-            assert encoder.encode(char.UniversalString(version_info[0] == 3 and 'abc' or unicode('abc'))) == ints2octs(
+            assert encoder.encode(char.UniversalString(sys.version_info[0] == 3 and 'abc' or unicode('abc'))) == ints2octs(
                 (28, 12, 0, 0, 0, 97, 0, 0, 0, 98, 0, 0, 0, 99)), 'Incorrect encoding'
 
 
-class BMPStringEncoderTestCase(unittest.TestCase):
+class BMPStringEncoderTestCase(BaseTestCase):
     def testEncoding(self):
-        assert encoder.encode(char.BMPString(version_info[0] == 3 and 'abc' or unicode('abc'))) == ints2octs(
+        assert encoder.encode(char.BMPString(sys.version_info[0] == 3 and 'abc' or unicode('abc'))) == ints2octs(
             (30, 6, 0, 97, 0, 98, 0, 99)), 'Incorrect encoding'
 
 
-class UTF8StringEncoderTestCase(unittest.TestCase):
+class UTF8StringEncoderTestCase(BaseTestCase):
     def testEncoding(self):
-        assert encoder.encode(char.UTF8String(version_info[0] == 3 and 'abc' or unicode('abc'))) == ints2octs(
+        assert encoder.encode(char.UTF8String(sys.version_info[0] == 3 and 'abc' or unicode('abc'))) == ints2octs(
             (12, 3, 97, 98, 99)), 'Incorrect encoding'
 
 
-class SequenceOfEncoderTestCase(unittest.TestCase):
+class SequenceOfEncoderTestCase(BaseTestCase):
     def testEmpty(self):
         s = univ.SequenceOf()
         assert encoder.encode(s) == ints2octs((48, 0))
@@ -373,8 +381,9 @@ class SequenceOfEncoderTestCase(unittest.TestCase):
         ) == ints2octs((48, 128, 36, 128, 4, 4, 113, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 3, 111, 119, 110, 0, 0, 0, 0))
 
 
-class SequenceOfEncoderWithSchemaTestCase(unittest.TestCase):
+class SequenceOfEncoderWithSchemaTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.SequenceOf(componentType=univ.OctetString())
 
     def __init(self):
@@ -404,7 +413,7 @@ class SequenceOfEncoderWithSchemaTestCase(unittest.TestCase):
         ) == ints2octs((48, 128, 36, 128, 4, 4, 113, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 3, 111, 119, 110, 0, 0, 0, 0))
 
 
-class SetOfEncoderTestCase(unittest.TestCase):
+class SetOfEncoderTestCase(BaseTestCase):
     def testEmpty(self):
         s = univ.SetOf()
         assert encoder.encode(s) == ints2octs((49, 0))
@@ -436,8 +445,9 @@ class SetOfEncoderTestCase(unittest.TestCase):
         ) == ints2octs((49, 128, 36, 128, 4, 4, 113, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 3, 111, 119, 110, 0, 0, 0, 0))
 
 
-class SetOfEncoderWithSchemaTestCase(unittest.TestCase):
+class SetOfEncoderWithSchemaTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.SetOf(componentType=univ.OctetString())
 
     def __init(self):
@@ -467,8 +477,9 @@ class SetOfEncoderWithSchemaTestCase(unittest.TestCase):
         ) == ints2octs((49, 128, 36, 128, 4, 4, 113, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 3, 111, 119, 110, 0, 0, 0, 0))
 
 
-class SequenceEncoderTestCase(unittest.TestCase):
+class SequenceEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Sequence()
         self.s.setComponentByPosition(0, univ.Null(''))
         self.s.setComponentByPosition(1, univ.OctetString('quick brown'))
@@ -493,8 +504,9 @@ class SequenceEncoderTestCase(unittest.TestCase):
         ) == ints2octs((48, 128, 5, 0, 36, 128, 4, 4, 113, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 3, 111, 119, 110, 0, 0, 2, 1, 1, 0, 0))
 
 
-class SequenceEncoderWithSchemaTestCase(unittest.TestCase):
+class SequenceEncoderWithSchemaTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Sequence(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('place-holder', univ.Null()),
@@ -617,8 +629,9 @@ class SequenceEncoderWithSchemaTestCase(unittest.TestCase):
                         0, 2, 1, 1, 0, 0))
 
 
-class ExpTaggedSequenceEncoderTestCase(unittest.TestCase):
+class ExpTaggedSequenceEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         s = univ.Sequence(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('number', univ.Integer()),
@@ -642,8 +655,9 @@ class ExpTaggedSequenceEncoderTestCase(unittest.TestCase):
         ) == ints2octs((101, 128, 48, 128, 2, 1, 12, 0, 0, 0, 0))
 
 
-class SetEncoderTestCase(unittest.TestCase):
+class SetEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Set()
         self.s.setComponentByPosition(0, univ.Null(''))
         self.s.setComponentByPosition(1, univ.OctetString('quick brown'))
@@ -668,8 +682,9 @@ class SetEncoderTestCase(unittest.TestCase):
         ) == ints2octs((49, 128, 5, 0, 36, 128, 4, 4, 113, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 3, 111, 119, 110, 0, 0, 2, 1, 1, 0, 0))
 
 
-class SetEncoderWithSchemaTestCase(unittest.TestCase):
+class SetEncoderWithSchemaTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Set(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('place-holder', univ.Null()),
@@ -791,7 +806,7 @@ class SetEncoderWithSchemaTestCase(unittest.TestCase):
         ) == ints2octs((49, 128, 5, 0, 36, 128, 4, 4, 113, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 3, 111, 119, 110, 0, 0, 2, 1, 1, 0, 0))
 
 
-class ChoiceEncoderTestCase(unittest.TestCase):
+class ChoiceEncoderTestCase(BaseTestCase):
 
     def testEmpty(self):
         s = univ.Choice()
@@ -834,8 +849,9 @@ class ChoiceEncoderTestCase(unittest.TestCase):
         ) == ints2octs((36, 128, 4, 4, 113, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 3, 111, 119, 110, 0, 0))
 
 
-class ChoiceEncoderWithSchemaTestCase(unittest.TestCase):
+class ChoiceEncoderWithSchemaTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Choice(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('place-holder', univ.Null('')),
@@ -877,8 +893,9 @@ class ChoiceEncoderWithSchemaTestCase(unittest.TestCase):
             (164, 128, 36, 128, 4, 3, 97, 98, 99, 4, 3, 100, 101, 102, 4, 2, 103, 104, 0, 0, 0, 0))
 
 
-class AnyEncoderTestCase(unittest.TestCase):
+class AnyEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Any(encoder.encode(univ.OctetString('fox')))
 
     def testUntagged(self):

--- a/tests/codec/cer/test_decoder.py
+++ b/tests/codec/cer/test_decoder.py
@@ -5,17 +5,20 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
+
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
+
+from tests.base import BaseTestCase
 
 from pyasn1.codec.cer import decoder
 from pyasn1.compat.octets import ints2octs, str2octs, null
 from pyasn1.error import PyAsn1Error
 
 
-class BooleanDecoderTestCase(unittest.TestCase):
+class BooleanDecoderTestCase(BaseTestCase):
     def testTrue(self):
         assert decoder.decode(ints2octs((1, 1, 255))) == (1, null)
 
@@ -34,7 +37,7 @@ class BooleanDecoderTestCase(unittest.TestCase):
         except PyAsn1Error:
             pass
 
-class BitStringDecoderTestCase(unittest.TestCase):
+class BitStringDecoderTestCase(BaseTestCase):
     def testShortMode(self):
         assert decoder.decode(
             ints2octs((3, 3, 6, 170, 128))
@@ -48,7 +51,7 @@ class BitStringDecoderTestCase(unittest.TestCase):
     # TODO: test failures on short chunked and long unchunked substrate samples
 
 
-class OctetStringDecoderTestCase(unittest.TestCase):
+class OctetStringDecoderTestCase(BaseTestCase):
     def testShortMode(self):
         assert decoder.decode(
             ints2octs((4, 15, 81, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120)),

--- a/tests/codec/cer/test_encoder.py
+++ b/tests/codec/cer/test_encoder.py
@@ -5,10 +5,13 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
+
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
+
+from tests.base import BaseTestCase
 
 from pyasn1.type import namedtype, univ, useful
 from pyasn1.codec.cer import encoder
@@ -16,7 +19,7 @@ from pyasn1.compat.octets import ints2octs
 from pyasn1.error import PyAsn1Error
 
 
-class BooleanEncoderTestCase(unittest.TestCase):
+class BooleanEncoderTestCase(BaseTestCase):
     def testTrue(self):
         assert encoder.encode(univ.Boolean(1)) == ints2octs((1, 1, 255))
 
@@ -24,7 +27,7 @@ class BooleanEncoderTestCase(unittest.TestCase):
         assert encoder.encode(univ.Boolean(0)) == ints2octs((1, 1, 0))
 
 
-class BitStringEncoderTestCase(unittest.TestCase):
+class BitStringEncoderTestCase(BaseTestCase):
     def testShortMode(self):
         assert encoder.encode(
             univ.BitString((1, 0) * 5)
@@ -34,7 +37,7 @@ class BitStringEncoderTestCase(unittest.TestCase):
         assert encoder.encode(univ.BitString((1, 0) * 501)) == ints2octs((3, 127, 6) + (170,) * 125 + (128,))
 
 
-class OctetStringEncoderTestCase(unittest.TestCase):
+class OctetStringEncoderTestCase(BaseTestCase):
     def testShortMode(self):
         assert encoder.encode(
             univ.OctetString('Quick brown fox')
@@ -46,7 +49,7 @@ class OctetStringEncoderTestCase(unittest.TestCase):
         ) == ints2octs((36, 128, 4, 130, 3, 232) + (81,) * 1000 + (4, 1, 81, 0, 0))
 
 
-class GeneralizedTimeEncoderTestCase(unittest.TestCase):
+class GeneralizedTimeEncoderTestCase(BaseTestCase):
     #    def testExtraZeroInSeconds(self):
     #        try:
     #            assert encoder.encode(
@@ -104,7 +107,7 @@ class GeneralizedTimeEncoderTestCase(unittest.TestCase):
              ) == ints2octs((24, 13, 50, 48, 49, 55, 48, 56, 48, 49, 49, 50, 48, 49, 90))
 
 
-class UTCTimeEncoderTestCase(unittest.TestCase):
+class UTCTimeEncoderTestCase(BaseTestCase):
     def testFractionOfSecond(self):
         try:
             assert encoder.encode(
@@ -146,7 +149,7 @@ class UTCTimeEncoderTestCase(unittest.TestCase):
              ) == ints2octs((23, 11, 57, 57, 48, 56, 48, 49, 49, 50, 48, 49, 90))
 
 
-class SequenceOfEncoderTestCase(unittest.TestCase):
+class SequenceOfEncoderTestCase(BaseTestCase):
     def testEmpty(self):
         s = univ.SequenceOf()
         assert encoder.encode(s) == ints2octs((48, 128, 0, 0))
@@ -176,8 +179,9 @@ class SequenceOfEncoderTestCase(unittest.TestCase):
         assert encoder.encode(s) == ints2octs((48, 128, 4, 1, 97, 4, 1, 98, 0, 0))
 
 
-class SequenceOfEncoderWithSchemaTestCase(unittest.TestCase):
+class SequenceOfEncoderWithSchemaTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.SequenceOf(componentType=univ.OctetString())
 
     def testEmpty(self):
@@ -209,7 +213,7 @@ class SequenceOfEncoderWithSchemaTestCase(unittest.TestCase):
         assert encoder.encode(self.s) == ints2octs((48, 128, 4, 1, 97, 4, 1, 98, 0, 0))
 
 
-class SetOfEncoderTestCase(unittest.TestCase):
+class SetOfEncoderTestCase(BaseTestCase):
     def testEmpty(self):
         s = univ.SetOf()
         assert encoder.encode(s) == ints2octs((49, 128, 0, 0))
@@ -239,8 +243,9 @@ class SetOfEncoderTestCase(unittest.TestCase):
         assert encoder.encode(s) == ints2octs((49, 128, 4, 1, 97, 4, 1, 98, 0, 0))
 
 
-class SetOfEncoderWithSchemaTestCase(unittest.TestCase):
+class SetOfEncoderWithSchemaTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.SetOf(componentType=univ.OctetString())
 
     def testEmpty(self):
@@ -276,8 +281,9 @@ class SetOfEncoderWithSchemaTestCase(unittest.TestCase):
         assert encoder.encode(self.s) == ints2octs((49, 128, 4, 1, 97, 4, 1, 98, 0, 0))
 
 
-class SetEncoderTestCase(unittest.TestCase):
+class SetEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Set()
         self.s.setComponentByPosition(0, univ.Null(''))
         self.s.setComponentByPosition(1, univ.OctetString('quick brown'))
@@ -302,8 +308,9 @@ class SetEncoderTestCase(unittest.TestCase):
         ) == ints2octs((49, 128, 2, 1, 1, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 5, 0, 0, 0))
 
 
-class SetEncoderWithSchemaTestCase(unittest.TestCase):
+class SetEncoderWithSchemaTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Set(componentType=namedtype.NamedTypes(
             namedtype.NamedType('place-holder', univ.Null('')),
             namedtype.OptionalNamedType('first-name', univ.OctetString()),
@@ -353,8 +360,9 @@ class SetEncoderWithSchemaTestCase(unittest.TestCase):
         ) == ints2octs((49, 128, 2, 1, 1, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 5, 0, 0, 0))
 
 
-class SetWithChoiceWithSchemaEncoderTestCase(unittest.TestCase):
+class SetWithChoiceWithSchemaEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         c = univ.Choice(componentType=namedtype.NamedTypes(
             namedtype.NamedType('actual', univ.Boolean(0))
         ))
@@ -370,8 +378,9 @@ class SetWithChoiceWithSchemaEncoderTestCase(unittest.TestCase):
         assert encoder.encode(self.s) == ints2octs((49, 128, 1, 1, 255, 5, 0, 0, 0))
 
 
-class SetEncoderTestCase(unittest.TestCase):
+class SetEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Set()
         self.s.setComponentByPosition(0, univ.Null(''))
         self.s.setComponentByPosition(1, univ.OctetString('quick brown'))
@@ -396,8 +405,9 @@ class SetEncoderTestCase(unittest.TestCase):
         ) == ints2octs((49, 128, 2, 1, 1, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 5, 0, 0, 0))
 
 
-class SequenceEncoderTestCase(unittest.TestCase):
+class SequenceEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Sequence()
         self.s.setComponentByPosition(0, univ.Null(''))
         self.s.setComponentByPosition(1, univ.OctetString('quick brown'))
@@ -422,8 +432,9 @@ class SequenceEncoderTestCase(unittest.TestCase):
         ) == ints2octs((48, 128, 5, 0, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 2, 1, 1, 0, 0))
 
 
-class SequenceEncoderWithSchemaTestCase(unittest.TestCase):
+class SequenceEncoderWithSchemaTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Sequence(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('place-holder', univ.Null('')),
@@ -475,8 +486,9 @@ class SequenceEncoderWithSchemaTestCase(unittest.TestCase):
         ) == ints2octs((48, 128, 5, 0, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 2, 1, 1, 0, 0))
 
 
-class NestedOptionalSequenceEncoderTestCase(unittest.TestCase):
+class NestedOptionalSequenceEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         inner = univ.Sequence(
             componentType=namedtype.NamedTypes(
                 namedtype.OptionalNamedType('first-name', univ.OctetString()),
@@ -564,8 +576,9 @@ class NestedOptionalSequenceEncoderTestCase(unittest.TestCase):
         assert encoder.encode(s) == ints2octs((48, 128, 48, 128, 2, 1, 123, 0, 0, 0, 0))
 
 
-class NestedOptionalChoiceEncoderTestCase(unittest.TestCase):
+class NestedOptionalChoiceEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         layer3 = univ.Sequence(
             componentType=namedtype.NamedTypes(
                 namedtype.OptionalNamedType('first-name', univ.OctetString()),
@@ -625,8 +638,9 @@ class NestedOptionalChoiceEncoderTestCase(unittest.TestCase):
         assert encoder.encode(s) == ints2octs((48, 128, 0, 0))
 
 
-class NestedOptionalSequenceOfEncoderTestCase(unittest.TestCase):
+class NestedOptionalSequenceOfEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         layer2 = univ.SequenceOf(
             componentType=univ.OctetString()
         )

--- a/tests/codec/der/test_decoder.py
+++ b/tests/codec/der/test_decoder.py
@@ -5,17 +5,20 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
+
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
+
+from tests.base import BaseTestCase
 
 from pyasn1.codec.der import decoder
 from pyasn1.compat.octets import ints2octs, null
 from pyasn1.error import PyAsn1Error
 
 
-class BitStringDecoderTestCase(unittest.TestCase):
+class BitStringDecoderTestCase(BaseTestCase):
     def testShortMode(self):
         assert decoder.decode(
             ints2octs((3, 127, 6) + (170,) * 125 + (128,))
@@ -42,7 +45,7 @@ class BitStringDecoderTestCase(unittest.TestCase):
             assert 0, 'chunked encoding tolerated'
 
 
-class OctetStringDecoderTestCase(unittest.TestCase):
+class OctetStringDecoderTestCase(BaseTestCase):
     def testShortMode(self):
         assert decoder.decode(
             '\004\017Quick brown fox'.encode()

--- a/tests/codec/der/test_encoder.py
+++ b/tests/codec/der/test_encoder.py
@@ -5,18 +5,20 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
+
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
 
+from tests.base import BaseTestCase
+
 from pyasn1.type import namedtype, univ
 from pyasn1.codec.der import encoder
 from pyasn1.compat.octets import ints2octs
-from pyasn1.error import PyAsn1Error
 
 
-class OctetStringEncoderTestCase(unittest.TestCase):
+class OctetStringEncoderTestCase(BaseTestCase):
     def testDefModeShort(self):
         assert encoder.encode(
             univ.OctetString('Quick brown fox')
@@ -28,7 +30,7 @@ class OctetStringEncoderTestCase(unittest.TestCase):
         ) == ints2octs((4, 130, 39, 16) + (81,) * 10000)
 
 
-class BitStringEncoderTestCase(unittest.TestCase):
+class BitStringEncoderTestCase(BaseTestCase):
     def testDefModeShort(self):
         assert encoder.encode(
             univ.BitString((1,))
@@ -40,8 +42,10 @@ class BitStringEncoderTestCase(unittest.TestCase):
         ) == ints2octs((3, 130, 39, 17, 0) + (255,) * 10000)
 
 
-class SetOfEncoderTestCase(unittest.TestCase):
+class SetOfEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         self.s = univ.SetOf(componentType=univ.OctetString())
 
     def testDefMode1(self):
@@ -72,12 +76,15 @@ class SetOfEncoderTestCase(unittest.TestCase):
 
         assert encoder.encode(self.s) == ints2octs((49, 6, 4, 1, 97, 4, 1, 98))
 
-class SetWithChoiceEncoderTestCase(unittest.TestCase):
+class SetWithChoiceEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         c = univ.Choice(componentType=namedtype.NamedTypes(
             namedtype.NamedType('name', univ.OctetString()),
             namedtype.NamedType('amount', univ.Boolean()))
         )
+
         self.s = univ.Set(componentType=namedtype.NamedTypes(
             namedtype.NamedType('value', univ.Integer(5)),
             namedtype.NamedType('status', c))
@@ -94,8 +101,10 @@ class SetWithChoiceEncoderTestCase(unittest.TestCase):
         assert encoder.encode(self.s) == ints2octs((49, 6, 1, 1, 255, 2, 1, 5))
 
 
-class NestedOptionalSequenceEncoderTestCase(unittest.TestCase):
+class NestedOptionalSequenceEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         inner = univ.Sequence(
             componentType=namedtype.NamedTypes(
                 namedtype.OptionalNamedType('first-name', univ.OctetString()),
@@ -183,8 +192,10 @@ class NestedOptionalSequenceEncoderTestCase(unittest.TestCase):
         assert encoder.encode(s) == ints2octs((48, 5, 48, 3, 2, 1, 123))
 
 
-class NestedOptionalChoiceEncoderTestCase(unittest.TestCase):
+class NestedOptionalChoiceEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         layer3 = univ.Sequence(
             componentType=namedtype.NamedTypes(
                 namedtype.OptionalNamedType('first-name', univ.OctetString()),
@@ -244,8 +255,10 @@ class NestedOptionalChoiceEncoderTestCase(unittest.TestCase):
         assert encoder.encode(s) == ints2octs((48, 0))
 
 
-class NestedOptionalSequenceOfEncoderTestCase(unittest.TestCase):
+class NestedOptionalSequenceOfEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         layer2 = univ.SequenceOf(
             componentType=univ.OctetString()
         )

--- a/tests/codec/native/test_decoder.py
+++ b/tests/codec/native/test_decoder.py
@@ -5,17 +5,20 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
+
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
 
-from pyasn1.type import tag, namedtype, univ, char
+from tests.base import BaseTestCase
+
+from pyasn1.type import namedtype, univ
 from pyasn1.codec.native import decoder
 from pyasn1.error import PyAsn1Error
 
 
-class BadAsn1SpecTestCase(unittest.TestCase):
+class BadAsn1SpecTestCase(BaseTestCase):
     def testBadSpec(self):
         try:
             decoder.decode('', asn1Spec='not an Asn1Item')
@@ -25,7 +28,7 @@ class BadAsn1SpecTestCase(unittest.TestCase):
             assert 0, 'Invalid asn1Spec accepted'
 
 
-class IntegerDecoderTestCase(unittest.TestCase):
+class IntegerDecoderTestCase(BaseTestCase):
     def testPosInt(self):
         assert decoder.decode(12, asn1Spec=univ.Integer()) == univ.Integer(12)
 
@@ -33,7 +36,7 @@ class IntegerDecoderTestCase(unittest.TestCase):
         assert decoder.decode(-12, asn1Spec=univ.Integer()) == univ.Integer(-12)
 
 
-class BooleanDecoderTestCase(unittest.TestCase):
+class BooleanDecoderTestCase(BaseTestCase):
     def testTrue(self):
         assert decoder.decode(True, asn1Spec=univ.Boolean()) == univ.Boolean(True)
 
@@ -41,33 +44,35 @@ class BooleanDecoderTestCase(unittest.TestCase):
         assert decoder.decode(False, asn1Spec=univ.Boolean()) == univ.Boolean(False)
 
 
-class BitStringDecoderTestCase(unittest.TestCase):
+class BitStringDecoderTestCase(BaseTestCase):
     def testSimple(self):
         assert decoder.decode('11111111', asn1Spec=univ.BitString()) == univ.BitString(hexValue='ff')
 
 
-class OctetStringDecoderTestCase(unittest.TestCase):
+class OctetStringDecoderTestCase(BaseTestCase):
     def testSimple(self):
         assert decoder.decode('Quick brown fox', asn1Spec=univ.OctetString()) == univ.OctetString('Quick brown fox')
 
 
-class NullDecoderTestCase(unittest.TestCase):
+class NullDecoderTestCase(BaseTestCase):
     def testNull(self):
         assert decoder.decode(None, asn1Spec=univ.Null()) == univ.Null()
 
 
-class ObjectIdentifierDecoderTestCase(unittest.TestCase):
+class ObjectIdentifierDecoderTestCase(BaseTestCase):
     def testOne(self):
         assert decoder.decode('1.3.6.11', asn1Spec=univ.ObjectIdentifier()) == univ.ObjectIdentifier('1.3.6.11')
 
 
-class RealDecoderTestCase(unittest.TestCase):
+class RealDecoderTestCase(BaseTestCase):
     def testSimple(self):
         assert decoder.decode(1.33, asn1Spec=univ.Real()) == univ.Real(1.33)
 
 
-class SequenceDecoderTestCase(unittest.TestCase):
+class SequenceDecoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         self.s = univ.Sequence(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('place-holder', univ.Null()),
@@ -84,8 +89,10 @@ class SequenceDecoderTestCase(unittest.TestCase):
         assert decoder.decode({'place-holder': None, 'first-name': 'xx', 'age': 33}, asn1Spec=self.s) == s
 
 
-class ChoiceDecoderTestCase(unittest.TestCase):
+class ChoiceDecoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         self.s = univ.Choice(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('place-holder', univ.Null()),
@@ -100,8 +107,10 @@ class ChoiceDecoderTestCase(unittest.TestCase):
         assert decoder.decode({'first-name': 'xx'}, asn1Spec=self.s) == s
 
 
-class AnyDecoderTestCase(unittest.TestCase):
+class AnyDecoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         self.s = univ.Any()
 
     def testSimple(self):

--- a/tests/codec/native/test_encoder.py
+++ b/tests/codec/native/test_encoder.py
@@ -5,28 +5,33 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
+
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
 
-from pyasn1.type import tag, namedtype, univ
+from tests.base import BaseTestCase
+
+from pyasn1.type import namedtype, univ
 from pyasn1.codec.native import encoder
 from pyasn1.compat.octets import str2octs
 from pyasn1.error import PyAsn1Error
 
 
-class BadAsn1SpecTestCase(unittest.TestCase):
+class BadAsn1SpecTestCase(BaseTestCase):
     def testBadValueType(self):
         try:
             encoder.encode('not an Asn1Item')
+
         except PyAsn1Error:
             pass
+
         else:
             assert 0, 'Invalid value type accepted'
 
 
-class IntegerEncoderTestCase(unittest.TestCase):
+class IntegerEncoderTestCase(BaseTestCase):
     def testPosInt(self):
         assert encoder.encode(univ.Integer(12)) == 12
 
@@ -34,7 +39,7 @@ class IntegerEncoderTestCase(unittest.TestCase):
         assert encoder.encode(univ.Integer(-12)) == -12
 
 
-class BooleanEncoderTestCase(unittest.TestCase):
+class BooleanEncoderTestCase(BaseTestCase):
     def testTrue(self):
         assert encoder.encode(univ.Boolean(1)) is True
 
@@ -42,33 +47,35 @@ class BooleanEncoderTestCase(unittest.TestCase):
         assert encoder.encode(univ.Boolean(0)) is False
 
 
-class BitStringEncoderTestCase(unittest.TestCase):
+class BitStringEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.b = univ.BitString((1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1))
 
     def testValue(self):
         assert encoder.encode(self.b) == '101010011000101'
 
 
-class OctetStringEncoderTestCase(unittest.TestCase):
+class OctetStringEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.o = univ.OctetString('Quick brown fox')
 
     def testValue(self):
         assert encoder.encode(self.o) == str2octs('Quick brown fox')
 
 
-class NullEncoderTestCase(unittest.TestCase):
+class NullEncoderTestCase(BaseTestCase):
     def testNull(self):
         assert encoder.encode(univ.Null('')) is None
 
 
-class ObjectIdentifierEncoderTestCase(unittest.TestCase):
+class ObjectIdentifierEncoderTestCase(BaseTestCase):
     def testOne(self):
         assert encoder.encode(univ.ObjectIdentifier((1, 3, 6, 0, 12345))) == '1.3.6.0.12345'
 
 
-class RealEncoderTestCase(unittest.TestCase):
+class RealEncoderTestCase(BaseTestCase):
     def testChar(self):
         assert encoder.encode(univ.Real((123, 10, 11))) == 1.23e+13
 
@@ -79,8 +86,10 @@ class RealEncoderTestCase(unittest.TestCase):
         assert encoder.encode(univ.Real('-inf')) == float('-inf')
 
 
-class SequenceEncoderTestCase(unittest.TestCase):
+class SequenceEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         self.s = univ.Sequence(componentType=namedtype.NamedTypes(
             namedtype.NamedType('place-holder', univ.Null('')),
             namedtype.OptionalNamedType('first-name', univ.OctetString('')),
@@ -95,13 +104,17 @@ class SequenceEncoderTestCase(unittest.TestCase):
         assert encoder.encode(s) == {'place-holder': None, 'first-name': str2octs('abc'), 'age': 123}
 
 
-class ChoiceEncoderTestCase(unittest.TestCase):
+class ChoiceEncoderTestCase(BaseTestCase):
     def setUp(self):
-        self.s = univ.Choice(componentType=namedtype.NamedTypes(
-            namedtype.NamedType('place-holder', univ.Null('')),
-            namedtype.NamedType('number', univ.Integer(0)),
-            namedtype.NamedType('string', univ.OctetString())
-        ))
+        BaseTestCase.setUp(self)
+
+        self.s = univ.Choice(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('place-holder', univ.Null('')),
+                namedtype.NamedType('number', univ.Integer(0)),
+                namedtype.NamedType('string', univ.OctetString())
+           )
+        )
 
     def testEmpty(self):
         try:
@@ -116,8 +129,9 @@ class ChoiceEncoderTestCase(unittest.TestCase):
         assert encoder.encode(self.s) == {'place-holder': None}
 
 
-class AnyEncoderTestCase(unittest.TestCase):
+class AnyEncoderTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.s = univ.Any(encoder.encode(univ.OctetString('fox')))
 
     def testSimple(self):

--- a/tests/compat/test_binary.py
+++ b/tests/compat/test_binary.py
@@ -5,15 +5,18 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
-from pyasn1.compat import binary
 
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
 
+from tests.base import BaseTestCase
 
-class BinaryTestCase(unittest.TestCase):
+from pyasn1.compat import binary
+
+
+class BinaryTestCase(BaseTestCase):
 
     def test_bin_zero(self):
         assert '0b0' == binary.bin(0)

--- a/tests/compat/test_integer.py
+++ b/tests/compat/test_integer.py
@@ -5,15 +5,18 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
-from pyasn1.compat import integer
 
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
 
+from tests.base import BaseTestCase
 
-class IntegerTestCase(unittest.TestCase):
+from pyasn1.compat import integer
+
+
+class IntegerTestCase(BaseTestCase):
 
     if sys.version_info[0] > 2:
 

--- a/tests/compat/test_octets.py
+++ b/tests/compat/test_octets.py
@@ -5,15 +5,18 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
-from pyasn1.compat import octets
 
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
 
+from tests.base import BaseTestCase
 
-class OctetsTestCase(unittest.TestCase):
+from pyasn1.compat import octets
+
+
+class OctetsTestCase(BaseTestCase):
 
     if sys.version_info[0] > 2:
 

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -5,16 +5,21 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
+
 try:
     import unittest2 as unittest
+
 except ImportError:
     import unittest
+
+from tests.base import BaseTestCase
 
 from pyasn1 import debug
 from pyasn1 import error
 
-class DebugCaseBase(unittest.TestCase):
+class DebugCaseBase(BaseTestCase):
     def testKnownFlags(self):
+        debug.setLogger(0)
         debug.setLogger(debug.Debug('all', 'encoder', 'decoder'))
         debug.setLogger(0)
 

--- a/tests/type/test_char.py
+++ b/tests/type/test_char.py
@@ -5,23 +5,28 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
-from pyasn1.type import char, univ, constraint
-from pyasn1.compat.octets import ints2octs
-from pyasn1.error import PyAsn1Error
 
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
 
+from tests.base import BaseTestCase
 
-class AbstractStringTestCase:
+from pyasn1.type import char, univ, constraint
+from pyasn1.compat.octets import ints2octs
+from pyasn1.error import PyAsn1Error
+
+
+class AbstractStringTestCase(object):
 
     initializer = ()
     encoding = 'us-ascii'
     asn1Type = None
 
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         self.asn1String = self.asn1Type(ints2octs(self.initializer), encoding=self.encoding)
         self.pythonString = ints2octs(self.initializer).decode(self.encoding)
 
@@ -107,28 +112,28 @@ class AbstractStringTestCase:
             assert list(reversed(self.asn1String)) == list(reversed(self.pythonString))
 
 
-class VisibleStringTestCase(AbstractStringTestCase, unittest.TestCase):
+class VisibleStringTestCase(AbstractStringTestCase, BaseTestCase):
 
     initializer = (97, 102)
     encoding = 'us-ascii'
     asn1Type = char.VisibleString
 
 
-class GeneralStringTestCase(AbstractStringTestCase, unittest.TestCase):
+class GeneralStringTestCase(AbstractStringTestCase, BaseTestCase):
 
     initializer = (169, 174)
     encoding = 'iso-8859-1'
     asn1Type = char.GeneralString
 
 
-class UTF8StringTestCase(AbstractStringTestCase, unittest.TestCase):
+class UTF8StringTestCase(AbstractStringTestCase, BaseTestCase):
 
     initializer = (209, 132, 208, 176)
     encoding = 'utf-8'
     asn1Type = char.UTF8String
 
 
-class BMPStringTestCase(AbstractStringTestCase, unittest.TestCase):
+class BMPStringTestCase(AbstractStringTestCase, BaseTestCase):
 
     initializer = (4, 48, 4, 68)
     encoding = 'utf-16-be'
@@ -139,7 +144,7 @@ if sys.version_info[0] > 2:
 
     # Somehow comparison of UTF-32 encoded strings does not work in Py2
 
-    class UniversalStringTestCase(AbstractStringTestCase, unittest.TestCase):
+    class UniversalStringTestCase(AbstractStringTestCase, BaseTestCase):
         initializer = (0, 0, 4, 48, 0, 0, 4, 68)
         encoding = 'utf-32-be'
         asn1Type = char.UniversalString

--- a/tests/type/test_constraint.py
+++ b/tests/type/test_constraint.py
@@ -5,17 +5,21 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
+
 try:
     import unittest2 as unittest
 
 except ImportError:
     import unittest
 
+from tests.base import BaseTestCase
+
 from pyasn1.type import constraint, error
 
 
-class SingleValueConstraintTestCase(unittest.TestCase):
+class SingleValueConstraintTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.c1 = constraint.SingleValueConstraint(1, 2)
         self.c2 = constraint.SingleValueConstraint(3, 4)
 
@@ -28,6 +32,7 @@ class SingleValueConstraintTestCase(unittest.TestCase):
     def testGoodVal(self):
         try:
             self.c1(1)
+
         except error.ValueConstraintError:
             assert 0, 'constraint check fails'
 
@@ -40,8 +45,9 @@ class SingleValueConstraintTestCase(unittest.TestCase):
             assert 0, 'constraint check fails'
 
 
-class ContainedSubtypeConstraintTestCase(unittest.TestCase):
+class ContainedSubtypeConstraintTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.c1 = constraint.ContainedSubtypeConstraint(
             constraint.SingleValueConstraint(12)
         )
@@ -61,8 +67,9 @@ class ContainedSubtypeConstraintTestCase(unittest.TestCase):
             assert 0, 'constraint check fails'
 
 
-class ValueRangeConstraintTestCase(unittest.TestCase):
+class ValueRangeConstraintTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.c1 = constraint.ValueRangeConstraint(1, 4)
 
     def testGoodVal(self):
@@ -80,8 +87,9 @@ class ValueRangeConstraintTestCase(unittest.TestCase):
             assert 0, 'constraint check fails'
 
 
-class ValueSizeConstraintTestCase(unittest.TestCase):
+class ValueSizeConstraintTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.c1 = constraint.ValueSizeConstraint(1, 2)
 
     def testGoodVal(self):
@@ -119,8 +127,9 @@ class PermittedAlphabetConstraintTestCase(SingleValueConstraintTestCase):
             assert 0, 'constraint check fails'
 
 
-class ConstraintsIntersectionTestCase(unittest.TestCase):
+class ConstraintsIntersectionTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.c1 = constraint.ConstraintsIntersection(
             constraint.SingleValueConstraint(4),
             constraint.ValueRangeConstraint(2, 4)
@@ -161,7 +170,7 @@ class ConstraintsIntersectionTestCase(unittest.TestCase):
             assert 0, 'constraint check fails'
 
 
-class InnerTypeConstraintTestCase(unittest.TestCase):
+class InnerTypeConstraintTestCase(BaseTestCase):
     def testConst1(self):
         c = constraint.InnerTypeConstraint(
             constraint.SingleValueConstraint(4)
@@ -203,8 +212,9 @@ class InnerTypeConstraintTestCase(unittest.TestCase):
         # Constraints compositions
 
 
-class ConstraintsIntersectionRangeTestCase(unittest.TestCase):
+class ConstraintsIntersectionRangeTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.c1 = constraint.ConstraintsIntersection(
             constraint.ValueRangeConstraint(1, 9),
             constraint.ValueRangeConstraint(2, 5)
@@ -225,8 +235,9 @@ class ConstraintsIntersectionRangeTestCase(unittest.TestCase):
             assert 0, 'constraint check fails'
 
 
-class ConstraintsUnionTestCase(unittest.TestCase):
+class ConstraintsUnionTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.c1 = constraint.ConstraintsUnion(
             constraint.SingleValueConstraint(5),
             constraint.ValueRangeConstraint(1, 3)
@@ -248,8 +259,9 @@ class ConstraintsUnionTestCase(unittest.TestCase):
             assert 0, 'constraint check fails'
 
 
-class ConstraintsExclusionTestCase(unittest.TestCase):
+class ConstraintsExclusionTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.c1 = constraint.ConstraintsExclusion(
             constraint.ValueRangeConstraint(2, 4)
         )
@@ -271,9 +283,12 @@ class ConstraintsExclusionTestCase(unittest.TestCase):
 
 # Constraints derivations
 
-class DirectDerivationTestCase(unittest.TestCase):
+class DirectDerivationTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         self.c1 = constraint.SingleValueConstraint(5)
+
         self.c2 = constraint.ConstraintsUnion(
             self.c1, constraint.ValueRangeConstraint(1, 3)
         )
@@ -287,14 +302,18 @@ class DirectDerivationTestCase(unittest.TestCase):
         assert self.c2.isSubTypeOf(self.c1), 'isSubTypeOf failed'
 
 
-class IndirectDerivationTestCase(unittest.TestCase):
+class IndirectDerivationTestCase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         self.c1 = constraint.ConstraintsIntersection(
             constraint.ValueRangeConstraint(1, 30)
         )
+
         self.c2 = constraint.ConstraintsIntersection(
             self.c1, constraint.ValueRangeConstraint(1, 20)
         )
+
         self.c2 = constraint.ConstraintsIntersection(
             self.c2, constraint.ValueRangeConstraint(1, 10)
         )
@@ -307,7 +326,7 @@ class IndirectDerivationTestCase(unittest.TestCase):
         assert not self.c2.isSuperTypeOf(self.c1), 'isSuperTypeOf failed'
         assert self.c2.isSubTypeOf(self.c1), 'isSubTypeOf failed'
 
-# TODO: how to apply size constriants to constructed types?
+# TODO: how to apply size constraints to constructed types?
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 

--- a/tests/type/test_namedtype.py
+++ b/tests/type/test_namedtype.py
@@ -5,17 +5,22 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
+
 try:
     import unittest2 as unittest
+
 except ImportError:
     import unittest
+
+from tests.base import BaseTestCase
 
 from pyasn1.type import namedtype, univ
 from pyasn1.error import PyAsn1Error
 
 
-class NamedTypeCaseBase(unittest.TestCase):
+class NamedTypeCaseBase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.e = namedtype.NamedType('age', univ.Integer(0))
 
     def testIter(self):
@@ -26,8 +31,10 @@ class NamedTypeCaseBase(unittest.TestCase):
         assert eval(repr(self.e), {'NamedType': namedtype.NamedType, 'Integer': univ.Integer}) == self.e, 'repr() fails'
 
 
-class NamedTypesCaseBase(unittest.TestCase):
+class NamedTypesCaseBase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         self.e = namedtype.NamedTypes(
             namedtype.NamedType('first-name', univ.OctetString('')),
             namedtype.OptionalNamedType('age', univ.Integer(0)),
@@ -35,9 +42,15 @@ class NamedTypesCaseBase(unittest.TestCase):
         )
 
     def testRepr(self):
-        assert eval(repr(self.e), {'NamedTypes': namedtype.NamedTypes, 'NamedType': namedtype.NamedType,
-                                   'OptionalNamedType': namedtype.OptionalNamedType, 'Integer': univ.Integer,
-                                   'OctetString': univ.OctetString}) == self.e, 'repr() fails'
+        assert eval(
+            repr(self.e), {
+                'NamedTypes': namedtype.NamedTypes,
+                'NamedType': namedtype.NamedType,
+                'OptionalNamedType': namedtype.OptionalNamedType,
+                'Integer': univ.Integer,
+                'OctetString': univ.OctetString
+            }
+        ) == self.e, 'repr() fails'
 
     def testContains(self):
         assert 'first-name' in self.e
@@ -104,8 +117,10 @@ class NamedTypesCaseBase(unittest.TestCase):
         assert self.e.getPositionNearType(univ.OctetString.tagSet, 2) == 2
 
 
-class OrderedNamedTypesCaseBase(unittest.TestCase):
+class OrderedNamedTypesCaseBase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         self.e = namedtype.NamedTypes(
             namedtype.NamedType('first-name', univ.OctetString('')),
             namedtype.NamedType('age', univ.Integer(0))
@@ -116,7 +131,7 @@ class OrderedNamedTypesCaseBase(unittest.TestCase):
             'getTypeByPosition() fails'
 
 
-class DuplicateNamedTypesCaseBase(unittest.TestCase):
+class DuplicateNamedTypesCaseBase(BaseTestCase):
     def testDuplicateDefaultTags(self):
         nt = namedtype.NamedTypes(
             namedtype.NamedType('first-name', univ.Any()),

--- a/tests/type/test_namedval.py
+++ b/tests/type/test_namedval.py
@@ -5,17 +5,21 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
+
 try:
     import unittest2 as unittest
 
 except ImportError:
     import unittest
 
+from tests.base import BaseTestCase
+
 from pyasn1.type import namedval
 
 
-class NamedValuesCaseBase(unittest.TestCase):
+class NamedValuesCaseBase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.e = namedval.NamedValues(('off', 0), ('on', 1))
 
     def testDict(self):

--- a/tests/type/test_tag.py
+++ b/tests/type/test_tag.py
@@ -5,17 +5,21 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
+
 try:
     import unittest2 as unittest
 
 except ImportError:
     import unittest
 
+from tests.base import BaseTestCase
+
 from pyasn1.type import tag
 
 
-class TagTestCaseBase(unittest.TestCase):
+class TagTestCaseBase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
         self.t1 = tag.Tag(tag.tagClassUniversal, tag.tagFormatSimple, 3)
         self.t2 = tag.Tag(tag.tagClassUniversal, tag.tagFormatSimple, 3)
 
@@ -38,11 +42,14 @@ class TagCmpTestCase(TagTestCaseBase):
                self.t1[2] == self.t2[2], 'tag sequence protocol fails'
 
 
-class TagSetTestCaseBase(unittest.TestCase):
+class TagSetTestCaseBase(BaseTestCase):
     def setUp(self):
+        BaseTestCase.setUp(self)
+
         self.ts1 = tag.initTagSet(
             tag.Tag(tag.tagClassUniversal, tag.tagFormatSimple, 12)
         )
+
         self.ts2 = tag.initTagSet(
             tag.Tag(tag.tagClassUniversal, tag.tagFormatSimple, 12)
         )

--- a/tests/type/test_useful.py
+++ b/tests/type/test_useful.py
@@ -6,14 +6,16 @@
 #
 import sys
 import datetime
-from pyasn1.type import useful
-from pyasn1.error import PyAsn1Error
 
 try:
     import unittest2 as unittest
+
 except ImportError:
     import unittest
 
+from tests.base import BaseTestCase
+
+from pyasn1.type import useful
 
 class FixedOffset(datetime.tzinfo):
     def __init__(self, offset, name):
@@ -34,11 +36,11 @@ UTC = FixedOffset(0, 'UTC')
 UTC2 = FixedOffset(120, 'UTC')
 
 
-class ObjectDescriptorTestCase(unittest.TestCase):
+class ObjectDescriptorTestCase(BaseTestCase):
     pass
 
 
-class GeneralizedTimeTestCase(unittest.TestCase):
+class GeneralizedTimeTestCase(BaseTestCase):
 
     def testFromDateTime(self):
         assert useful.GeneralizedTime.fromDateTime(datetime.datetime(2017, 7, 11, 0, 1, 2, 30000, tzinfo=UTC)) == '20170711000102.3Z'
@@ -71,7 +73,7 @@ class GeneralizedTimeTestCase(unittest.TestCase):
         assert datetime.datetime(2017, 7, 11, 0) == useful.GeneralizedTime('2017071100').asDateTime
 
 
-class UTCTimeTestCase(unittest.TestCase):
+class UTCTimeTestCase(BaseTestCase):
 
     def testFromDateTime(self):
         assert useful.UTCTime.fromDateTime(datetime.datetime(2017, 7, 11, 0, 1, 2, tzinfo=UTC)) == '170711000102Z'


### PR DESCRIPTION
Apparently, silly bugs like string interpolation accumulate in debugging message over time. This PR is to run all unit tests under full pyasn1 debugging (the actual output is ignored).

Also fixed a couple of crashes found in debug messages.