### PR TITLE
Fixed crash on EXPLICIT'ly tagged SEQUENCE component encoding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,11 @@
 Revision 0.3.6, released XX-09-2017
 -----------------------------------
 
+- End-of-octets encoding optimized at ASN.1 encoders
 - The __getitem__/__setitem__ behavior of Set/Sequence and SetOf/SequenceOf
   objects aligned with the canonical Mapping and Sequence protocols in part
+- Fixed crash in ASN.1 encoder when encoding an explicitly tagged
+  component of a Sequence
 
 Revision 0.3.5, released 16-09-2017
 -----------------------------------

--- a/pyasn1/codec/ber/encoder.py
+++ b/pyasn1/codec/ber/encoder.py
@@ -16,6 +16,10 @@ __all__ = ['encode']
 class AbstractItemEncoder(object):
     supportIndefLenMode = 1
 
+    # An outcome of otherwise legit call `encodeFun(eoo.endOfOctets)`
+    eooIntegerSubstrate = (0, 0)
+    eooOctetsSubstrate = ints2octs(eooIntegerSubstrate)
+
     # noinspection PyMethodMayBeStatic
     def encodeTag(self, singleTag, isConstructed):
         tagClass, tagFormat, tagId = singleTag
@@ -85,11 +89,18 @@ class AbstractItemEncoder(object):
 
             if isOctets:
                 substrate = ints2octs(header) + substrate
-            else:
-                substrate = ints2octs(header + substrate)
 
-            if not defModeOverride:
-                substrate += encodeFun(eoo.endOfOctets, defMode=defModeOverride)
+                if not defModeOverride:
+                    substrate += self.eooOctetsSubstrate
+
+            else:
+                substrate = header + substrate
+
+                if not defModeOverride:
+                    substrate += self.eooIntegerSubstrate
+
+        if not isOctets:
+            substrate = ints2octs(substrate)
 
         return substrate
 
@@ -506,6 +517,7 @@ class Encoder(object):
 
         if logger:
             logger('codec %s built %s octets of substrate: %s\nencoder completed' % (concreteEncoder, len(substrate), debug.hexdump(substrate)))
+
         return substrate
 
 #: Turns ASN.1 object into BER octet stream.

--- a/tests/codec/ber/test_encoder.py
+++ b/tests/codec/ber/test_encoder.py
@@ -655,6 +655,26 @@ class ExpTaggedSequenceEncoderTestCase(BaseTestCase):
         ) == ints2octs((101, 128, 48, 128, 2, 1, 12, 0, 0, 0, 0))
 
 
+class ExpTaggedSequenceComponentEncoderTestCase(BaseTestCase):
+    def setUp(self):
+        BaseTestCase.setUp(self)
+        self.s = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('number', univ.Boolean().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
+            )
+        )
+
+        self.s[0] = True
+
+    def testDefMode(self):
+        assert encoder.encode(self.s) == ints2octs((48, 5, 160, 3, 1, 1, 1))
+
+    def testIndefMode(self):
+        assert encoder.encode(
+            self.s, defMode=False
+        ) == ints2octs((48, 128, 160, 3, 1, 1, 1, 0, 0, 0, 0))
+
+
 class SetEncoderTestCase(BaseTestCase):
     def setUp(self):
         BaseTestCase.setUp(self)


### PR DESCRIPTION
As a by-product of this fix, the end-of-octets encoding simplified a great deal by replacing a fully-fledged encoder call with its static outcome. This should improve encoding performance.
