### PR TITLE
Implement value-replacing cloning of Choice object

### DIFF
--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -2697,7 +2697,7 @@ class Choice(Set):
         :raise :py:obj:`error.PyAsn1Error`:
             if the type of *value* is not allowed for this choice instance.
         """
-        cloned = univ.Choice.clone(self)
+        cloned = Set.clone(self)
         if value is not None:
             try:
                 tagSet = value.tagSet

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -2684,6 +2684,29 @@ class Choice(Set):
         if self._currentIdx is None:
             raise error.PyAsn1Error('Component not chosen')
 
+    def clone(self, value=None, **kwargs):
+        """Clone this instance.
+
+        If value is specified, use it as the clone's component value to it,
+        using its tag set as the component type selector.
+
+        :param value: (Optional) the component value.
+        :type value: :py:obj:`Asn1ItemBase`
+        :return: the cloned instance.
+        :rtype: :py:obj:`Choice`
+        :raise :py:obj:`error.PyAsn1Error`:
+            if the type of *value* is not allowed for this choice instance.
+        """
+        cloned = univ.Choice.clone(self)
+        if value is not None:
+            try:
+                tagSet = value.tagSet
+            except AttributeError:
+                raise error.PyAsn1Error('component value %r has no tag set'
+                                        % (value,))
+            cloned.setComponentByType(tagSet, value)
+        return cloned
+
     def _cloneComponentValues(self, myClone, cloneValueFlag):
         try:
             component = self.getComponent()

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -2687,8 +2687,8 @@ class Choice(Set):
     def clone(self, value=None, **kwargs):
         """Clone this instance.
 
-        If value is specified, use it as the clone's component value to it,
-        using its tag set as the component type selector.
+        If *value* is specified, use its tag as the component type selector,
+        and itself as the component value.
 
         :param value: (Optional) the component value.
         :type value: :py:obj:`Asn1ItemBase`


### PR DESCRIPTION
This enables use of a `Choice` subtype (such as `RFC1155-SMI::NetworkAddress`) as a table index, such as `RFC1213-MIB::atNetAddress`.