### PR TITLE
Remove None initializer support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,10 @@ Revision 0.4.1, released XX-10-2017
   or a Python value plus ASN.1 schema
 - BitString decoder optimised for better performance when running on
   constructed encoding
-- Sphinx documentation reaaranged, simplified and reworded
+- Sphinx documentation rearranged, simplified and reworded
+- The `isValue` singleton is now the only way to indicate ASN.1 schema
+  as opposed to ASN.1 schema instance. The legacy `None` initializer
+  support has been removed.
 
 Revision 0.3.7, released 04-10-2017
 -----------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Revision 0.4.1, released XX-10-2017
 - The `isValue` singleton is now the only way to indicate ASN.1 schema
   as opposed to ASN.1 schema instance. The legacy `None` initializer
   support has been removed.
+- Changed `Null` object initialization behaviour: previous default
+  value (`''`) is not set anymore. Thus `Null()` call produces a
+  ASN.1 schema object, while `Null('')` - value object.
 
 Revision 0.3.7, released 04-10-2017
 -----------------------------------

--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -284,7 +284,7 @@ class NullDecoder(AbstractSimpleDecoder):
 
         head, tail = substrate[:length], substrate[length:]
 
-        component = self._createComponent(asn1Spec, tagSet, None, **options)
+        component = self._createComponent(asn1Spec, tagSet, noValue, **options)
 
         if head:
             raise error.PyAsn1Error('Unexpected %d-octet substrate for Null' % length)

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -185,8 +185,9 @@ class NoValue(object):
 
     def __getattr__(self, attr):
         if attr in self.skipMethods:
-            raise AttributeError('attribute %s not present' % attr)
-        raise error.PyAsn1Error('No value for "%s"' % attr)
+            raise AttributeError('Attribute %s not present' % attr)
+
+        raise error.PyAsn1Error('Attempted "%s" operation on ASN.1 schema object' % attr)
 
     def __repr__(self):
         return '%s()' % self.__class__.__name__

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -119,7 +119,7 @@ class Asn1ItemBase(Asn1Item):
     @staticmethod
     def isNoValue(*values):
         for value in values:
-            if value is not None and value is not noValue:
+            if value is not noValue:
                 return False
         return True
 
@@ -201,7 +201,7 @@ class AbstractSimpleAsn1Item(Asn1ItemBase):
 
     def __init__(self, value=noValue, **kwargs):
         Asn1ItemBase.__init__(self, **kwargs)
-        if value is noValue or value is None:
+        if value is noValue:
             value = self.defaultValue
         else:
             value = self.prettyIn(value)
@@ -307,7 +307,7 @@ class AbstractSimpleAsn1Item(Asn1ItemBase):
           :
               new instance of |ASN.1| type/value
         """
-        if value is noValue or value is None:
+        if value is noValue:
             if not kwargs:
                 return self
 
@@ -349,7 +349,7 @@ class AbstractSimpleAsn1Item(Asn1ItemBase):
          :
              new instance of |ASN.1| type/value
         """
-        if value is noValue or value is None:
+        if value is noValue:
             if not kwargs:
                 return self
 
@@ -448,7 +448,7 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
         representation = '%s(%s)' % (self.__class__.__name__, ', '.join(representation))
         if self._componentValues:
             for idx, component in enumerate(self._componentValues):
-                if component is None or component is noValue:
+                if component is noValue:
                     continue
                 representation += '.setComponentByPosition(%d, %s)' % (idx, repr(component))
         return representation

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -1158,7 +1158,7 @@ class Null(OctetString):
     Parameters
     ----------
     value : :class:`str` or :py:class:`~pyasn1.type.univ.Null` object
-        Python empty string literal or *Null* class instance.
+        Python empty string literal or any object that evaluates to `False`
 
     tagSet: :py:class:`~pyasn1.type.tag.TagSet`
         Object representing non-default ASN.1 tag(s)
@@ -1168,7 +1168,6 @@ class Null(OctetString):
     : :py:class:`pyasn1.error.PyAsn1Error`
         On constraint violation or bad initializer.
     """
-    defaultValue = ''.encode()  # This is tightly constrained
 
     #: Set (on class, not on instance) or return a
     #: :py:class:`~pyasn1.type.tag.TagSet` object representing ASN.1 tag(s)
@@ -1232,6 +1231,11 @@ class Null(OctetString):
         """
         return OctetString.subtype(self, value, **kwargs)
 
+    def prettyIn(self, value):
+        if value:
+            return value
+
+        return octets.str2octs('')
 
 if sys.version_info[0] <= 2:
     intTypes = (int, long)

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -414,7 +414,7 @@ class BitString(base.AbstractSimpleAsn1Item):
             return self.bitLength
 
     def __init__(self, value=noValue, **kwargs):
-        if value is noValue or value is None:
+        if value is noValue:
             if kwargs:
                 try:
                     value = self.fromBinaryString(kwargs.pop('binValue'), internalFormat=True)
@@ -428,7 +428,7 @@ class BitString(base.AbstractSimpleAsn1Item):
                 except KeyError:
                     pass
 
-        if value is noValue or value is None:
+        if value is noValue:
             if self.defaultBinValue is not noValue:
                 value = self.fromBinaryString(self.defaultBinValue, internalFormat=True)
 
@@ -839,7 +839,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
 
     def __init__(self, value=noValue, **kwargs):
         if kwargs:
-            if value is noValue or value is None:
+            if value is noValue:
                 try:
                     value = self.fromBinaryString(kwargs.pop('binValue'))
 
@@ -852,7 +852,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
                 except KeyError:
                     pass
 
-        if value is noValue or value is None:
+        if value is noValue:
             if self.defaultBinValue is not noValue:
                 value = self.fromBinaryString(self.defaultBinValue)
 
@@ -1879,9 +1879,6 @@ class SequenceOfAndSetOfBase(base.AbstractConstructedAsn1Item):
         IndexError:
             When idx > len(self)
         """
-        if value is None:  # backward compatibility
-            value = noValue
-
         componentType = self.componentType
 
         try:
@@ -2319,9 +2316,6 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
         -------
         self
         """
-        if value is None:  # backward compatibility
-            value = noValue
-
         componentType = self.componentType
         componentTypeLen = self._componentTypeLen
 

--- a/tests/codec/ber/test_encoder.py
+++ b/tests/codec/ber/test_encoder.py
@@ -746,11 +746,11 @@ class SequenceEncoderWithComponentsSchemaTestCase(BaseTestCase):
 
     def __init(self):
         self.s.clear()
-        self.s.setComponentByPosition(0)
+        self.s.setComponentByPosition(0, '')
 
     def __initWithOptional(self):
         self.s.clear()
-        self.s.setComponentByPosition(0)
+        self.s.setComponentByPosition(0, '')
         self.s.setComponentByPosition(1, 'quick brown')
 
     def __initWithDefaulted(self):
@@ -991,11 +991,11 @@ class SetEncoderWithComponentsSchemaTestCase(BaseTestCase):
 
     def __init(self):
         self.s.clear()
-        self.s.setComponentByPosition(0)
+        self.s.setComponentByPosition(0, '')
 
     def __initWithOptional(self):
         self.s.clear()
-        self.s.setComponentByPosition(0)
+        self.s.setComponentByPosition(0, '')
         self.s.setComponentByPosition(1, 'quick brown')
 
     def __initWithDefaulted(self):

--- a/tests/codec/native/test_decoder.py
+++ b/tests/codec/native/test_decoder.py
@@ -56,7 +56,7 @@ class OctetStringDecoderTestCase(BaseTestCase):
 
 class NullDecoderTestCase(BaseTestCase):
     def testNull(self):
-        assert decoder.decode(None, asn1Spec=univ.Null()) == univ.Null()
+        assert decoder.decode(None, asn1Spec=univ.Null()) == univ.Null('')
 
 
 class ObjectIdentifierDecoderTestCase(BaseTestCase):
@@ -83,7 +83,7 @@ class SequenceDecoderTestCase(BaseTestCase):
 
     def testSimple(self):
         s = self.s.clone()
-        s[0] = univ.Null()
+        s[0] = univ.Null('')
         s[1] = univ.OctetString('xx')
         s[2] = univ.Integer(33)
         assert decoder.decode({'place-holder': None, 'first-name': 'xx', 'age': 33}, asn1Spec=self.s) == s

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -546,11 +546,31 @@ class OctetStringTestCase(BaseTestCase):
 
 
 class Null(BaseTestCase):
+
+    def testInit(self):
+        assert not univ.Null().isValue
+        assert univ.Null(0) == str2octs('')
+        assert univ.Null(False) == str2octs('')
+        assert univ.Null('') == str2octs('')
+        assert univ.Null(None) == str2octs('')
+
+        try:
+            assert univ.Null(True)
+
+        except PyAsn1Error:
+            pass
+
+        try:
+            assert univ.Null('xxx')
+
+        except PyAsn1Error:
+            pass
+
     def testStr(self):
         assert str(univ.Null('')) == '', 'str() fails'
 
     def testRepr(self):
-        assert eval(repr(univ.Null()), {'Null': univ.Null}) == univ.Null(), 'repr() fails'
+        assert eval(repr(univ.Null('')), {'Null': univ.Null}) == univ.Null(''), 'repr() fails'
 
     def testTag(self):
         assert univ.Null().tagSet == tag.TagSet(
@@ -571,7 +591,7 @@ class Null(BaseTestCase):
         class Null(univ.Null):
             pass
 
-        assert not Null()
+        assert not Null('')
 
 
 class RealTestCase(BaseTestCase):


### PR DESCRIPTION
Previously, ASN.1 objects can be initialized with either `noValue` singleton object or `None` object to indicate ASN.1 schema rather than a schema instance (e.g. a value). The `None` initializer is legacy and should not be widely used.

This PR removes special treatment of the `None` initializer.

Additionally this PR removes default value from ASN.1 `Null` object making it a schema object by default.