### PR TITLE
Fix to encoder to omit empty substrate only for constructed types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ Revision 0.4.1, released XX-10-2017
 - Changed `Null` object initialization behaviour: previous default
   value (`''`) is not set anymore. Thus `Null()` call produces a
   ASN.1 schema object, while `Null('')` - value object.
+- Fixed ASN.1 encoder not to omit empty substrate produced for inner
+  component if the inner component belongs to the simple class (as
+  opposed to constructed class).
 
 Revision 0.3.7, released 04-10-2017
 -----------------------------------

--- a/pyasn1/codec/ber/encoder.py
+++ b/pyasn1/codec/ber/encoder.py
@@ -80,7 +80,7 @@ class AbstractItemEncoder(object):
                     value, asn1Spec, encodeFun, **options
                 )
 
-                if options.get('ifNotEmpty', False) and not substrate:
+                if not substrate and isConstructed and options.get('ifNotEmpty', False):
                     return substrate
 
                 # primitive form implies definite mode

--- a/tests/codec/der/test_encoder.py
+++ b/tests/codec/der/test_encoder.py
@@ -289,6 +289,73 @@ class NestedOptionalSequenceOfEncoderTestCase(BaseTestCase):
         assert encoder.encode(s) == ints2octs((48, 0))
 
 
+class EmptyInnerFieldOfSequenceEncoderTestCase(BaseTestCase):
+
+    def testInitializedOptionalNullIsEncoded(self):
+        self.s = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.OptionalNamedType('null', univ.Null())
+            )
+        )
+
+        self.s.clear()
+        self.s[0] = ''
+        assert encoder.encode(self.s) == ints2octs((48, 2, 5, 0))
+
+    def testUninitializedOptionalNullIsNotEncoded(self):
+        self.s = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.OptionalNamedType('null', univ.Null())
+            )
+        )
+
+        self.s.clear()
+        assert encoder.encode(self.s) == ints2octs((48, 0))
+
+    def testInitializedDefaultNullIsNotEncoded(self):
+        self.s = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.DefaultedNamedType('null', univ.Null(''))
+            )
+        )
+
+        self.s.clear()
+        self.s[0] = ''
+        assert encoder.encode(self.s) == ints2octs((48, 0))
+
+    def testInitializedOptionalOctetStringIsEncoded(self):
+        self.s = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.OptionalNamedType('str', univ.OctetString())
+            )
+        )
+
+        self.s.clear()
+        self.s[0] = ''
+        assert encoder.encode(self.s) == ints2octs((48, 2, 4, 0))
+
+    def testUninitializedOptionalOctetStringIsNotEncoded(self):
+        self.s = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.OptionalNamedType('str', univ.OctetString())
+            )
+        )
+
+        self.s.clear()
+        assert encoder.encode(self.s) == ints2octs((48, 0))
+
+    def testInitializedDefaultOctetStringIsNotEncoded(self):
+        self.s = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.DefaultedNamedType('str', univ.OctetString(''))
+            )
+        )
+
+        self.s.clear()
+        self.s[0] = ''
+        assert encoder.encode(self.s) == ints2octs((48, 0))
+
+
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes a bug which makes this code:

```
s = univ.Sequence(
    componentType=namedtype.NamedTypes(
         namedtype.OptionalNamedType('null', univ.Null())
    )
)
self.s[0] = ''
encoder.encode(s)
```

Producing `(48, 0)` rather than `(48, 2, 5, 0)` e.g. not encoding `Null`. This bug also affects any other simple ASN.1 type whenever being a field of a SET/SEQUENCE and being encoded into an empty octet-stream.
