### PR TITLE
Pickle protocol fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Revision 0.4.1, released XX-10-2017
   opposed to constructed class).
 - Fixed CER/DER encoders to respect tagged CHOICE when ordering
   SET components
+- Fixed ASN.1 types not to interfere with the Pickle protocol
 
 Revision 0.3.7, released 04-10-2017
 -----------------------------------

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -156,8 +156,9 @@ class NoValue(object):
     *PyAsn1Error* exception.
     """
     skipMethods = set(
-        # attributes
-        ('__getattribute__',
+        ('__slots__',
+         # attributes
+         '__getattribute__',
          '__getattr__',
          '__setattr__',
          '__delattr__',

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -155,9 +155,30 @@ class NoValue(object):
     Any operation attempted on the *noValue* object will raise the
     *PyAsn1Error* exception.
     """
-    skipMethods = ('__getattribute__', '__getattr__', '__setattr__', '__delattr__',
-                   '__class__', '__init__', '__del__', '__new__', '__repr__', 
-                   '__qualname__', '__objclass__', 'im_class', '__sizeof__')
+    skipMethods = set(
+        # attributes
+        ('__getattribute__',
+         '__getattr__',
+         '__setattr__',
+         '__delattr__',
+         # class instance
+         '__class__',
+         '__init__',
+         '__del__',
+         '__new__',
+         '__repr__',
+         '__qualname__',
+         '__objclass__',
+         'im_class',
+         '__sizeof__',
+         # pickle protocol
+         '__reduce__',
+         '__reduce_ex__',
+         '__getnewargs__',
+         '__getinitargs__',
+         '__getstate__',
+         '__setstate__')
+    )
 
     _instance = None
 

--- a/tests/type/test_char.py
+++ b/tests/type/test_char.py
@@ -5,6 +5,7 @@
 # License: http://pyasn1.sf.net/license.html
 #
 import sys
+import pickle
 
 try:
     import unittest2 as unittest
@@ -110,6 +111,21 @@ class AbstractStringTestCase(object):
     if sys.version_info[:2] > (2, 4):
         def testReverse(self):
             assert list(reversed(self.asn1String)) == list(reversed(self.pythonString))
+
+    def testSchemaPickling(self):
+        old_asn1 = self.asn1Type()
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == self.asn1Type
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = self.asn1String
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1 == self.asn1String
 
 
 class VisibleStringTestCase(AbstractStringTestCase, BaseTestCase):

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -6,6 +6,7 @@
 #
 import sys
 import math
+import pickle
 
 try:
     import unittest2 as unittest
@@ -296,6 +297,24 @@ class IntegerTestCase(BaseTestCase):
         )
 
 
+class IntegerPicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = univ.Integer()
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == univ.Integer
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = univ.Integer(-123)
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1 == -123
+
+
 class BooleanTestCase(BaseTestCase):
     def testTruth(self):
         assert univ.Boolean(True) and univ.Boolean(1), 'Truth initializer fails'
@@ -326,6 +345,24 @@ class BooleanTestCase(BaseTestCase):
             pass
         else:
             assert 0, 'constraint fail'
+
+
+class BooleanPicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = univ.Boolean()
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == univ.Boolean
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = univ.Boolean(True)
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1 == True
 
 
 class BitStringTestCase(BaseTestCase):
@@ -405,6 +442,24 @@ class BitStringTestCase(BaseTestCase):
             pass
 
         assert BitString('11000000011001').asInteger() == 12313
+
+
+class BitStringPicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = univ.BitString()
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == univ.BitString
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = univ.BitString((1, 0, 1, 0))
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1 == (1, 0, 1, 0)
 
 
 class OctetStringWithUnicodeMixIn(object):
@@ -545,6 +600,24 @@ class OctetStringTestCase(BaseTestCase):
         assert OctetString(hexValue="FA9823C43E43510DE3422") == ints2octs((250, 152, 35, 196, 62, 67, 81, 13, 227, 66, 32))
 
 
+class OctetStringPicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = univ.BitString()
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == univ.BitString
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = univ.BitString((1, 0, 1, 0))
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1 == (1, 0, 1, 0)
+
+
 class Null(BaseTestCase):
 
     def testInit(self):
@@ -592,6 +665,24 @@ class Null(BaseTestCase):
             pass
 
         assert not Null('')
+
+
+class NullPicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = univ.Null()
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == univ.Null
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = univ.Null('')
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert not new_asn1
 
 
 class RealTestCase(BaseTestCase):
@@ -727,6 +818,24 @@ class RealTestCase(BaseTestCase):
         assert Real(1.0) == 1.0
 
 
+class RealPicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = univ.Real()
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == univ.Real
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = univ.Real((1, 10, 3))
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1 == 1000
+
+
 class ObjectIdentifier(BaseTestCase):
     def testStr(self):
         assert str(univ.ObjectIdentifier((1, 3, 6))) == '1.3.6', 'str() fails'
@@ -785,6 +894,24 @@ class ObjectIdentifier(BaseTestCase):
             pass
 
         assert str(ObjectIdentifier((1, 3, 6))) == '1.3.6'
+
+
+class ObjectIdentifierPicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = univ.ObjectIdentifier()
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == univ.ObjectIdentifier
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = univ.ObjectIdentifier('2.3.1.1.2')
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1 == (2, 3, 1, 1, 2)
 
 
 class SequenceOf(BaseTestCase):
@@ -1025,6 +1152,26 @@ class SequenceOf(BaseTestCase):
         assert s.getComponentByPosition(0, instantiate=False) == str2octs('test')
         s.clear()
         assert s.getComponentByPosition(0, instantiate=False) is univ.noValue
+
+
+class SequenceOfPicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = univ.SequenceOf(componentType=univ.OctetString())
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == univ.SequenceOf
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = univ.SequenceOf(componentType=univ.OctetString())
+        old_asn1[0] = 'test'
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1
+        assert new_asn1 == [str2octs('test')]
 
 
 class Sequence(BaseTestCase):
@@ -1329,6 +1476,34 @@ class SequenceWithoutSchema(BaseTestCase):
         assert 'field-0' not in s
 
 
+class SequencePicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString())
+            )
+        )
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == univ.Sequence
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString())
+            )
+        )
+        old_asn1['name'] = 'test'
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1
+        assert new_asn1['name'] == str2octs('test')
+
+
 class SetOf(BaseTestCase):
     def setUp(self):
         BaseTestCase.setUp(self)
@@ -1355,6 +1530,27 @@ class SetOf(BaseTestCase):
         s[0] = 'abc'
         assert len(s) == 1
         assert s == [str2octs('abc')]
+
+
+
+class SetOfPicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = univ.SetOf(componentType=univ.OctetString())
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == univ.SetOf
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = univ.SetOf(componentType=univ.OctetString())
+        old_asn1[0] = 'test'
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1
+        assert new_asn1 == [str2octs('test')]
 
 
 class Set(BaseTestCase):
@@ -1441,6 +1637,34 @@ class Set(BaseTestCase):
         assert s.getComponentByPosition(1, instantiate=False) == str2octs('test')
         s.clear()
         assert s.getComponentByPosition(1, instantiate=False) is univ.noValue
+
+
+class SetPicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = univ.Set(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString())
+            )
+        )
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == univ.Set
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = univ.Set(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString())
+            )
+        )
+        old_asn1['name'] = 'test'
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1
+        assert new_asn1['name'] == str2octs('test')
 
 
 class Choice(BaseTestCase):
@@ -1588,6 +1812,36 @@ class Choice(BaseTestCase):
         assert s.getComponentByPosition(1, instantiate=False) == 123
         s.clear()
         assert s.getComponentByPosition(1, instantiate=False) is univ.noValue
+
+
+class ChoicePicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = univ.Choice(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString()),
+                namedtype.NamedType('id', univ.Integer())
+            )
+        )
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == univ.Choice
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = univ.Choice(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString()),
+                namedtype.NamedType('id', univ.Integer())
+            )
+        )
+        old_asn1['name'] = 'test'
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1
+        assert new_asn1['name'] == str2octs('test')
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/type/test_useful.py
+++ b/tests/type/test_useful.py
@@ -7,6 +7,7 @@
 import sys
 import datetime
 from copy import deepcopy
+import pickle
 
 try:
     import unittest2 as unittest
@@ -78,6 +79,24 @@ class GeneralizedTimeTestCase(BaseTestCase):
         assert dt == deepcopy(dt)
 
 
+class GeneralizedTimePicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = useful.GeneralizedTime()
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == useful.GeneralizedTime
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = useful.GeneralizedTime("20170916234254+0130")
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1 == old_asn1
+
+
 class UTCTimeTestCase(BaseTestCase):
 
     def testFromDateTime(self):
@@ -97,6 +116,25 @@ class UTCTimeTestCase(BaseTestCase):
 
     def testToDateTime4(self):
         assert datetime.datetime(2017, 7, 11, 0, 1) == useful.UTCTime('1707110001').asDateTime
+
+
+class UTCTimePicklingTestCase(unittest.TestCase):
+
+    def testSchemaPickling(self):
+        old_asn1 = useful.UTCTime()
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert type(new_asn1) == useful.UTCTime
+        assert old_asn1.isSameTypeWith(new_asn1)
+
+    def testValuePickling(self):
+        old_asn1 = useful.UTCTime("170711000102")
+        serialized = pickle.dumps(old_asn1)
+        assert serialized
+        new_asn1 = pickle.loads(serialized)
+        assert new_asn1 == old_asn1
+
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 


### PR DESCRIPTION
This PR essentially adds Pickle protocol magic methods to the `NoValue` whitelist. That should at least make pyasn1 not interfering with the Pickle protocol working.