### PR TITLE
Add default to .getComponentBy*()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Revision 0.4.1, released XX-10-2017
   or a Python value plus ASN.1 schema
 - BitString decoder optimised for better performance when running on
   constructed encoding
+- Constructed types' .getComponentBy*() methods accept the `default`
+  parameter to return instead if schema object is to be returned
 - Constructed types' .getComponentBy*() methods accept the `instantiate`
   parameter to disable automatic inner component instantiation
 - Fixed Choice.clear() to fully reset internal state of the object

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,7 +114,7 @@ html_theme = 'alabaster'
 # documentation.
 html_theme_options = {
     'logo': 'logo.svg',
-    'description': '<p align=center><i>Brewing free software</i></p>',
+    'description': '<p align=left><i><b>Brewing free software for the greater good</i></b></p>',
     'show_powered_by': False,
     'github_user': 'etingof',
     'github_repo': 'pyasn1',

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -1139,6 +1139,19 @@ class SequenceOf(BaseTestCase):
 
         assert n == o
 
+    def testGetComponentWithDefault(self):
+
+        class SequenceOf(univ.SequenceOf):
+            componentType = univ.OctetString()
+
+        s = SequenceOf()
+        assert s.getComponentByPosition(0, default=None, instantiate=False) is None
+        assert s.getComponentByPosition(0, default=None) is None
+        s[0] = 'test'
+        assert s.getComponentByPosition(0, default=None) is not None
+        assert s.getComponentByPosition(0, default=None) == str2octs('test')
+        s.clear()
+        assert s.getComponentByPosition(0, default=None) is None
 
     def testGetComponentNoInstantiation(self):
 
@@ -1375,6 +1388,25 @@ class Sequence(BaseTestCase):
         s = Sequence()
         s['name'] = 'abc'
         assert s['name'] == str2octs('abc')
+
+    def testGetComponentWithDefault(self):
+
+        class Sequence(univ.Sequence):
+            componentType = namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString('')),
+                namedtype.OptionalNamedType('nick', univ.OctetString()),
+            )
+
+        s = Sequence()
+
+        assert s[0] == str2octs('')
+        assert s.getComponentByPosition(1, default=None, instantiate=False) is None
+        assert s.getComponentByName('nick', default=None) is None
+        s[1] = 'test'
+        assert s.getComponentByPosition(1, default=None) is not None
+        assert s.getComponentByPosition(1, default=None) == str2octs('test')
+        s.clear()
+        assert s.getComponentByPosition(1, default=None) is None
 
     def testGetComponentNoInstantiation(self):
 
@@ -1619,6 +1651,24 @@ class Set(BaseTestCase):
         s['name'] = 'abc'
         assert s['name'] == str2octs('abc')
 
+    def testGetComponentWithDefault(self):
+
+        class Set(univ.Set):
+            componentType = namedtype.NamedTypes(
+                namedtype.NamedType('id', univ.Integer(123)),
+                namedtype.OptionalNamedType('nick', univ.OctetString()),
+            )
+
+        s = Set()
+        assert s[0] == 123
+        assert s.getComponentByPosition(1, default=None, instantiate=False) is None
+        assert s.getComponentByName('nick', default=None) is None
+        s[1] = 'test'
+        assert s.getComponentByPosition(1, default=None) is not None
+        assert s.getComponentByPosition(1, default=None) == str2octs('test')
+        s.clear()
+        assert s.getComponentByPosition(1, default=None) is None
+
     def testGetComponentNoInstantiation(self):
 
         class Set(univ.Set):
@@ -1791,6 +1841,27 @@ class Choice(BaseTestCase):
 
         c.setComponentByType(univ.OctetString.tagSet, 'abc')
         assert c.getName() == 'name'
+
+    def testGetComponentWithDefault(self):
+
+        s = univ.Choice(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString()),
+                namedtype.NamedType('id', univ.Integer())
+            )
+        )
+
+        assert s.getComponentByPosition(0, default=None, instantiate=False) is None
+        assert s.getComponentByPosition(1, default=None, instantiate=False) is None
+        assert s.getComponentByName('name', default=None, instantiate=False) is None
+        assert s.getComponentByName('id', default=None, instantiate=False) is None
+        assert s.getComponentByType(univ.OctetString.tagSet, default=None) is None
+        assert s.getComponentByType(univ.Integer.tagSet, default=None) is None
+        s[1] = 123
+        assert s.getComponentByPosition(1, default=None) is not None
+        assert s.getComponentByPosition(1, univ.noValue) == 123
+        s.clear()
+        assert s.getComponentByPosition(1, default=None, instantiate=False) is None
 
     def testGetComponentNoInstantiation(self):
 


### PR DESCRIPTION
This PR introduces `default` kwarg to the `.getComponentBy*()` methods which is returned instead of the schema object in case the latter is to be returned.

The aim here is to ease migration from older pyasn1 API where `.getComponentBy*()` used to return `None`, then switched to return `noValue` sentinel:

   x.getComponentByName('field')  # -> noValue
   x.getComponentByName('field', default=None)  # -> None
