### PR TITLE
Start `.prettyPrint` deprecation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
 
-Revision 0.4.1, released XX-10-2017
+Revision 0.4.1, released XX-11-2017
 -----------------------------------
 
 - ANY DEFINED BY clause support implemented
@@ -11,8 +11,14 @@ Revision 0.4.1, released XX-10-2017
   parameter to return instead if schema object is to be returned
 - Constructed types' .getComponentBy*() methods accept the `instantiate`
   parameter to disable automatic inner component instantiation
-- The ASN.1 types `__repr__` implementation reworked for better readability
+- The ASN.1 types' `__repr__` implementation reworked for better readability
   at the cost of not being `eval`-compliant
+- Most ASN.1 types' `__str__` magic methods (except for OctetString and
+  character types) reworked to call `.prettyPrint()` rather than `.prettyPrint`
+  calling `__str__` as it was before. The intention is to mostly deprecate
+  `.prettyPrint()` in favor of `str()`.
+  The other related change is that `str()` of enumerations and boolean types
+  will return string label instead of number.
 - Fixed Choice.clear() to fully reset internal state of the object
 - Sphinx documentation rearranged, simplified and reworded
 - The `isValue` singleton is now the only way to indicate ASN.1 schema

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Revision 0.4.1, released XX-11-2017
   at the cost of not being `eval`-compliant
 - Most ASN.1 types' `__str__` magic methods (except for OctetString and
   character types) reworked to call `.prettyPrint()` rather than `.prettyPrint`
-  calling `__str__` as it was before. The intention is to mostly deprecate
+  calling `__str__` as it was before. The intention is to eventually deprecate
   `.prettyPrint()` in favor of `str()`.
   The other related change is that `str()` of enumerations and boolean types
   will return string label instead of number.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ can use it along the lines of similar Python type (e.g. ASN.1
 >>> record = Record()
 >>> record['id'] = 123
 >>> record['room'] = 321
->>> print(record.prettyPrint())
+>>> str(record)
 Record:
  id=123
  room=321
@@ -146,7 +146,7 @@ Python objects:
 ```python
 >>> from pyasn1.codec.native.decoder import decode
 >>> record = decode({'id': 123, 'room': 321, 'house': 0}, asn1Spec=Record())
->>> print(record.prettyPrint())
+>>> str(record)
 Record:
  id=123
  room=321

--- a/docs/source/example-use-case.rst
+++ b/docs/source/example-use-case.rst
@@ -110,7 +110,7 @@ Once we have Python ASN.1 structures initialized, we could inspect them:
 
 .. code-block:: pycon
 
-    >>> print(private_key.prettyPrint())
+    >>> print('%s' % private_key)
     RSAPrivateKey:
      version=0
      modulus=280789907761334970323210643584308373...

--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -1362,7 +1362,7 @@ class Decoder(object):
 #: .. code-block:: pycon
 #:
 #:    >>> s, _ = decode(b'0\t\x02\x01\x01\x02\x01\x02\x02\x01\x03')
-#:    >>> print(s.prettyPrint())
+#:    >>> str(s)
 #:    SequenceOf:
 #:     1 2 3
 #:
@@ -1372,7 +1372,7 @@ class Decoder(object):
 #:
 #:    >>> seq = SequenceOf(componentType=Integer())
 #:    >>> s, _ = decode(b'0\t\x02\x01\x01\x02\x01\x02\x02\x01\x03', asn1Spec=seq)
-#:    >>> print(s.prettyPrint())
+#:    >>> str(s)
 #:    SequenceOf:
 #:     1 2 3
 #:

--- a/pyasn1/codec/cer/decoder.py
+++ b/pyasn1/codec/cer/decoder.py
@@ -97,7 +97,7 @@ class Decoder(decoder.Decoder):
 #: .. code-block:: pycon
 #:
 #:    >>> s, _ = decode(b'0\x80\x02\x01\x01\x02\x01\x02\x02\x01\x03\x00\x00')
-#:    >>> print(s.prettyPrint())
+#:    >>> str(s)
 #:    SequenceOf:
 #:     1 2 3
 #:
@@ -107,7 +107,7 @@ class Decoder(decoder.Decoder):
 #:
 #:    >>> seq = SequenceOf(componentType=Integer())
 #:    >>> s, _ = decode(b'0\x80\x02\x01\x01\x02\x01\x02\x02\x01\x03\x00\x00', asn1Spec=seq)
-#:    >>> print(s.prettyPrint())
+#:    >>> str(s)
 #:    SequenceOf:
 #:     1 2 3
 #:

--- a/pyasn1/codec/der/decoder.py
+++ b/pyasn1/codec/der/decoder.py
@@ -77,7 +77,7 @@ class Decoder(decoder.Decoder):
 #: .. code-block:: pycon
 #:
 #:    >>> s, _ = decode(b'0\t\x02\x01\x01\x02\x01\x02\x02\x01\x03')
-#:    >>> print(s.prettyPrint())
+#:    >>> str(s)
 #:    SequenceOf:
 #:     1 2 3
 #:
@@ -87,7 +87,7 @@ class Decoder(decoder.Decoder):
 #:
 #:    >>> seq = SequenceOf(componentType=Integer())
 #:    >>> s, _ = decode(b'0\t\x02\x01\x01\x02\x01\x02\x02\x01\x03', asn1Spec=seq)
-#:    >>> print(s.prettyPrint())
+#:    >>> str(s)
 #:    SequenceOf:
 #:     1 2 3
 #:

--- a/pyasn1/codec/native/decoder.py
+++ b/pyasn1/codec/native/decoder.py
@@ -202,7 +202,7 @@ class Decoder(object):
 #:
 #:    >>> seq = SequenceOf(componentType=Integer())
 #:    >>> s, _ = decode([1, 2, 3], asn1Spec=seq)
-#:    >>> print(s.prettyPrint())
+#:    >>> str(s)
 #:    SequenceOf:
 #:     1 2 3
 #:

--- a/pyasn1/codec/native/encoder.py
+++ b/pyasn1/codec/native/encoder.py
@@ -43,7 +43,7 @@ class OctetStringEncoder(AbstractItemEncoder):
 
 class TextStringEncoder(AbstractItemEncoder):
     def encode(self, value, encodeFun, **options):
-        return value.prettyPrint()
+        return str(value)
 
 
 class NullEncoder(AbstractItemEncoder):

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -52,6 +52,9 @@ class Asn1ItemBase(Asn1Item):
 
         self.__dict__[name] = value
 
+    def __str__(self):
+        return self.prettyPrint()
+
     @property
     def readOnly(self):
         return self._readOnly
@@ -122,6 +125,9 @@ class Asn1ItemBase(Asn1Item):
             if value is not noValue:
                 return False
         return True
+
+    def prettyPrint(self, scope=0):
+        raise NotImplementedError()
 
     # backward compatibility
 
@@ -211,6 +217,9 @@ class NoValue(object):
 
         raise error.PyAsn1Error('Attempted "%s" operation on ASN.1 schema object' % attr)
 
+    def __repr__(self):
+        return '<no value>'
+
 
 noValue = NoValue()
 
@@ -251,9 +260,6 @@ class AbstractSimpleAsn1Item(Asn1ItemBase):
             representation += ' payload [%s]' % value
 
         return '<%s>' % representation
-
-    def __str__(self):
-        return str(self._value)
 
     def __eq__(self, other):
         return self is other and True or self._value == other
@@ -414,17 +420,7 @@ class AbstractSimpleAsn1Item(Asn1ItemBase):
         return str(value)
 
     def prettyPrint(self, scope=0):
-        """Return human-friendly object representation as a text.
-
-        Returns
-        -------
-        : :class:`str`
-            human-friendly type and/or value representation.
-        """
-        if self.isValue:
-            return self.prettyOut(self._value)
-        else:
-            return '<no value>'
+        return self.prettyOut(self._value)
 
     # noinspection PyUnusedLocal
     def prettyPrintType(self, scope=0):
@@ -508,6 +504,9 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
     else:
         def __bool__(self):
             return self._componentValues and True or False
+
+    def __len__(self):
+        return len(self._componentValues)
 
     def _cloneComponentValues(self, myClone, cloneValueFlag):
         pass
@@ -628,9 +627,6 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
         for k in kwargs:
             self[k] = kwargs[k]
         return self
-
-    def __len__(self):
-        return len(self._componentValues)
 
     def clear(self):
         self._componentValues = []

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -218,7 +218,7 @@ class NoValue(object):
         raise error.PyAsn1Error('Attempted "%s" operation on ASN.1 schema object' % attr)
 
     def __repr__(self):
-        return '<no value>'
+        return '<%s object at %s>' % (self.__class__.__name__, id(self))
 
 
 noValue = NoValue()

--- a/pyasn1/type/char.py
+++ b/pyasn1/type/char.py
@@ -50,7 +50,9 @@ class AbstractCharacterString(univ.OctetString):
     if sys.version_info[0] <= 2:
         def __str__(self):
             try:
+                # `str` is Py2 text representation
                 return self._value.encode(self.encoding)
+
             except UnicodeEncodeError:
                 raise error.PyAsn1Error(
                     "Can't encode string '%s' with codec %s" % (self._value, self.encoding)
@@ -85,6 +87,7 @@ class AbstractCharacterString(univ.OctetString):
 
     else:
         def __str__(self):
+            # `unicode` is Py3 text representation
             return str(self._value)
 
         def __bytes__(self):
@@ -119,8 +122,8 @@ class AbstractCharacterString(univ.OctetString):
         def asNumbers(self, padding=True):
             return tuple(bytes(self))
 
-    def prettyOut(self, value):
-        return value
+    def prettyPrint(self, scope=0):
+        return AbstractCharacterString.__str__(self)
 
     def __reversed__(self):
         return reversed(self._value)

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -282,7 +282,8 @@ class IntegerTestCase(BaseTestCase):
             namedValues = univ.Integer.namedValues.clone(('asn1', 1))
 
         assert Integer('asn1') == 1, 'named val fails'
-        assert str(Integer('asn1')) != 'asn1', 'named val __str__() fails'
+        assert int(Integer('asn1')) == 1, 'named val fails'
+        assert str(Integer('asn1')) == 'asn1', 'named val __str__() fails'
 
     def testSubtype(self):
         assert univ.Integer().subtype(
@@ -323,7 +324,10 @@ class BooleanTestCase(BaseTestCase):
         assert not univ.Boolean(False) and not univ.Boolean(0), 'False initializer fails'
 
     def testStr(self):
-        assert str(univ.Boolean(1)) in ('1', '1L'), 'str() fails'
+        assert str(univ.Boolean(1)) == 'True', 'str() fails'
+
+    def testInt(self):
+        assert int(univ.Boolean(1)) == 1, 'int() fails'
 
     def testRepr(self):
         assert 'Boolean' in repr(univ.Boolean(1))


### PR DESCRIPTION
This PR moves the `.prettyPrint` ASN.1 types functionality under the `__str__` magic method. The goal is to make ASN.1 schema introspection more intuitive and Pythonic.

The only exception is `OctetString` - `str` on it used to return octet-stream (Py2) or text (Py3) while `.prettyPrint()` used to return hexified contents. This PR does not change this for backward compatibility reasons.
