### PR TITLE
Relax open type field type check on assignment

### DIFF
--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -583,11 +583,7 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
                                 asn1Spec=openType
                             )
 
-                            asn1Object.setComponentByPosition(
-                                idx, component,
-                                matchTags=False,
-                                matchConstraints=False
-                            )
+                            asn1Object.setComponentByPosition(idx, component)
 
             else:
                 asn1Object.verifySizeSpec()
@@ -723,11 +719,7 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
                             )
 
                             if component is not eoo.endOfOctets:
-                                asn1Object.setComponentByPosition(
-                                    idx, component,
-                                    matchTags=False,
-                                    matchConstraints=False
-                                )
+                                asn1Object.setComponentByPosition(idx, component)
 
                 else:
                     asn1Object.verifySizeSpec()

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -2352,7 +2352,8 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
                                   subComponentType.isSuperTypeOf)
 
                 if not subtypeChecker(value, matchTags, matchConstraints):
-                    raise error.PyAsn1Error('Component value is tag-incompatible: %r vs %r' % (value, componentType))
+                    if not componentType[idx].openType:
+                        raise error.PyAsn1Error('Component value is tag-incompatible: %r vs %r' % (value, componentType))
 
         if verifyConstraints and value.isValue:
             try:

--- a/tests/codec/ber/test_encoder.py
+++ b/tests/codec/ber/test_encoder.py
@@ -14,7 +14,7 @@ except ImportError:
 
 from tests.base import BaseTestCase
 
-from pyasn1.type import tag, namedtype, univ, char
+from pyasn1.type import tag, namedtype, opentype, univ, char
 from pyasn1.codec.ber import encoder
 from pyasn1.compat.octets import ints2octs
 from pyasn1.error import PyAsn1Error
@@ -731,6 +731,121 @@ class SequenceEncoderWithSchemaTestCase(BaseTestCase):
         assert encoder.encode(
             self.v, asn1Spec=self.s, defMode=False, maxChunkSize=4
         ) == ints2octs((48, 128, 5, 0, 36, 128, 4, 4, 113, 117, 105, 99, 4, 4, 107, 32, 98, 114, 4, 3, 111, 119, 110, 0, 0, 2, 1, 1, 0, 0))
+
+
+class SequenceEncoderWithUntaggedOpenTypesTestCase(BaseTestCase):
+    def setUp(self):
+        BaseTestCase.setUp(self)
+
+        openType = opentype.OpenType(
+            'id',
+            {1: univ.Integer(),
+             2: univ.OctetString()}
+        )
+        self.s = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('id', univ.Integer()),
+                namedtype.NamedType('blob', univ.Any(), openType=openType)
+            )
+        )
+
+    def testEncodeOpenTypeChoiceOne(self):
+        self.s.clear()
+
+        self.s[0] = 1
+        self.s[1] = univ.Integer(12)
+
+        assert encoder.encode(self.s, asn1Spec=self.s) == ints2octs(
+            (48, 6, 2, 1, 1, 2, 1, 12)
+        )
+
+    def testEncodeOpenTypeChoiceTwo(self):
+        self.s.clear()
+
+        self.s[0] = 2
+        self.s[1] = univ.OctetString('quick brown')
+
+        assert encoder.encode(self.s, asn1Spec=self.s) == ints2octs(
+            (48, 16, 2, 1, 2, 4, 11, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110)
+        )
+
+    def testEncodeOpenTypeUnknownId(self):
+        self.s.clear()
+
+        self.s[0] = 2
+        self.s[1] = univ.ObjectIdentifier('1.3.6')
+
+        try:
+            encoder.encode(self.s, asn1Spec=self.s)
+
+        except PyAsn1Error:
+            assert False, 'incompatible open type tolerated'
+
+    def testEncodeOpenTypeIncompatibleType(self):
+        self.s.clear()
+
+        self.s[0] = 2
+        self.s[1] = univ.ObjectIdentifier('1.3.6')
+
+        try:
+            encoder.encode(self.s, asn1Spec=self.s)
+
+        except PyAsn1Error:
+            assert False, 'incompatible open type tolerated'
+
+
+class SequenceEncoderWithImplicitlyTaggedOpenTypesTestCase(BaseTestCase):
+    def setUp(self):
+        BaseTestCase.setUp(self)
+
+        openType = opentype.OpenType(
+            'id',
+            {1: univ.Integer(),
+             2: univ.OctetString()}
+        )
+        self.s = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('id', univ.Integer()),
+                namedtype.NamedType('blob', univ.Any().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 3)), openType=openType)
+            )
+        )
+
+    def testEncodeOpenTypeChoiceOne(self):
+        self.s.clear()
+
+        self.s[0] = 1
+        self.s[1] = univ.Integer(12)
+
+        assert encoder.encode(self.s, asn1Spec=self.s) == ints2octs(
+            (48, 8, 2, 1, 1, 131, 3, 2, 1, 12)
+        )
+
+
+class SequenceEncoderWithExplicitlyTaggedOpenTypesTestCase(BaseTestCase):
+    def setUp(self):
+        BaseTestCase.setUp(self)
+
+        openType = opentype.OpenType(
+            'id',
+            {1: univ.Integer(),
+             2: univ.OctetString()}
+        )
+        self.s = univ.Sequence(
+            componentType=namedtype.NamedTypes(
+                namedtype.NamedType('id', univ.Integer()),
+                namedtype.NamedType('blob', univ.Any().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 3)), openType=openType)
+            )
+        )
+
+    def testEncodeOpenTypeChoiceOne(self):
+        self.s.clear()
+
+        self.s[0] = 1
+        self.s[1] = univ.Integer(12)
+
+        assert encoder.encode(self.s, asn1Spec=self.s) == ints2octs(
+            (48, 8, 2, 1, 1, 163, 3, 2, 1, 12)
+        )
 
 
 class SequenceEncoderWithComponentsSchemaTestCase(BaseTestCase):

--- a/tests/type/__main__.py
+++ b/tests/type/__main__.py
@@ -12,6 +12,7 @@ except ImportError:
 
 suite = unittest.TestLoader().loadTestsFromNames(
     ['tests.type.test_constraint.suite',
+     'tests.type.test_opentype.suite',
      'tests.type.test_namedtype.suite',
      'tests.type.test_namedval.suite',
      'tests.type.test_tag.suite',

--- a/tests/type/test_opentype.py
+++ b/tests/type/test_opentype.py
@@ -1,0 +1,111 @@
+#
+# This file is part of pyasn1 software.
+#
+# Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+# License: http://snmplabs.com/pyasn1/license.html
+#
+import sys
+
+try:
+    import unittest2 as unittest
+
+except ImportError:
+    import unittest
+
+from tests.base import BaseTestCase
+
+from pyasn1.type import univ
+from pyasn1.type import tag
+from pyasn1.type import constraint
+from pyasn1.type import namedtype
+from pyasn1.type import namedval
+from pyasn1.type import opentype
+from pyasn1.type import error
+from pyasn1.compat.octets import str2octs
+from pyasn1.compat.octets import ints2octs
+from pyasn1.compat.octets import octs2ints
+from pyasn1.error import PyAsn1Error
+
+
+class UntaggedAnyTestCase(BaseTestCase):
+
+    def setUp(self):
+        BaseTestCase.setUp(self)
+
+        class Sequence(univ.Sequence):
+            componentType = namedtype.NamedTypes(
+                namedtype.NamedType('id', univ.Integer()),
+                namedtype.NamedType('blob', univ.Any())
+            )
+
+        self.s = Sequence()
+
+    def testTypeCheckOnAssignment(self):
+
+        self.s.clear()
+
+        self.s['blob'] = univ.Any(str2octs('xxx'))
+
+        # this should succeed because Any is untagged and unconstrained
+        self.s['blob'] = univ.Integer(123)
+
+
+class TaggedAnyTestCase(BaseTestCase):
+
+    def setUp(self):
+        BaseTestCase.setUp(self)
+
+        self.taggedAny = univ.Any().subtype(implicitTag=tag.Tag(tag.tagClassPrivate, tag.tagFormatSimple, 20))
+
+        class Sequence(univ.Sequence):
+            componentType = namedtype.NamedTypes(
+                namedtype.NamedType('id', univ.Integer()),
+                namedtype.NamedType('blob', self.taggedAny)
+            )
+
+        self.s = Sequence()
+
+    def testTypeCheckOnAssignment(self):
+
+        self.s.clear()
+
+        self.s['blob'] = self.taggedAny.clone('xxx')
+
+        try:
+            self.s.setComponentByName('blob', univ.Integer(123))
+
+        except PyAsn1Error:
+            pass
+
+        else:
+            assert False, 'non-open type assignment tolerated'
+
+
+class TaggedAnyOpenTypeTestCase(BaseTestCase):
+
+    def setUp(self):
+        BaseTestCase.setUp(self)
+
+        self.taggedAny = univ.Any().subtype(implicitTag=tag.Tag(tag.tagClassPrivate, tag.tagFormatSimple, 20))
+
+        class Sequence(univ.Sequence):
+            componentType = namedtype.NamedTypes(
+                namedtype.NamedType('id', univ.Integer()),
+                namedtype.NamedType('blob', self.taggedAny, openType=opentype.OpenType(name='id'))
+            )
+
+        self.s = Sequence()
+
+    def testTypeCheckOnAssignment(self):
+
+        self.s.clear()
+
+        self.s['blob'] = univ.Any(str2octs('xxx'))
+        self.s['blob'] = univ.Integer(123)
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -16,7 +16,12 @@ except ImportError:
 
 from tests.base import BaseTestCase
 
-from pyasn1.type import univ, tag, constraint, namedtype, namedval, error
+from pyasn1.type import univ
+from pyasn1.type import tag
+from pyasn1.type import constraint
+from pyasn1.type import namedtype
+from pyasn1.type import namedval
+from pyasn1.type import error
 from pyasn1.compat.octets import str2octs, ints2octs, octs2ints
 from pyasn1.error import PyAsn1Error
 


### PR DESCRIPTION
This PR disables ASN.1 type check on `Sequence`/`Set` field assignment if the field being assigned is marked as an open type.

In fact, before this PR, one could assign pretty much any type to the untagged `Any` field based on the fact that the untagged and unconstrained `Any` is considered being a supertype to any possible ASN.1 type.

It also adds some more test cases for open type en/decoding.