### PR TITLE
sys.getsizeof() may raise TypeError

### DIFF
--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -149,9 +149,13 @@ class NoValueTestCase(BaseTestCase):
         try:
             if hasattr(sys, 'getsizeof'):
                 sys.getsizeof(univ.noValue)
+            else:
+                raise unittest.SkipTest("no sys.getsizeof() method")
 
         except PyAsn1Error:
             assert False, 'sizeof failed for NoValue object'
+        except TypeError:
+            raise unittest.SkipTest("sys.getsizeof() raises TypeError")
 
 
 class IntegerTestCase(BaseTestCase):


### PR DESCRIPTION
Not all implementations have to implement getsizeof() and may raise
TypeError instead. Notably, Pypy will always raise TypeError (unless a
default value is provided).