### PR TITLE
Fix the entrypoint of asn1ate

### DIFF
--- a/docs/source/example-use-case.rst
+++ b/docs/source/example-use-case.rst
@@ -45,7 +45,7 @@ tool:
 
 .. code-block:: bash
 
-    $ pyasn1gen.py pkcs-1.asn > rsakey.py
+    $ asn1ate pkcs-1.asn > rsakey.py
 
 Though it may not work out as, as it stands now, asn1ate does not support
 all ASN.1 language constructs.


### PR DESCRIPTION
As [defined in setup.py](https://github.com/kimgr/asn1ate/blob/7ade34d0e3439b8ee0d9d5095a1426bde99f6a48/setup.py#L51), asn1ate define an entry point 'asn1ate' which is probably more straightforward than looking for the full path to the script.