### PR TITLE
Fix defaulted constructed SEQUENCE component initialization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
 
-Revision 0.4.5, released XX-08-2018
+Revision 0.4.5, released XX-10-2018
 -----------------------------------
 
 - Debug logging refactored for more efficiency when disabled and
@@ -8,6 +8,7 @@ Revision 0.4.5, released XX-08-2018
   from codec main loop as it used to be.
 - More debug logging added to BER family of codecs to ease encoding
   problems troubleshooting.
+- Fixed defaulted constructed SEQUENCE component initialization.
 
 Revision 0.4.4, released 26-07-2018
 -----------------------------------

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -2347,7 +2347,9 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
 
         if value is noValue:
             if componentTypeLen:
-                value = componentType.getTypeByPosition(idx).clone()
+                value = componentType.getTypeByPosition(idx)
+                if isinstance(value, base.AbstractConstructedAsn1Item):
+                    value = value.clone(cloneValueFlag=componentType[idx].isDefaulted)
 
             elif currentValue is noValue:
                 raise error.PyAsn1Error('Component type not defined')

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -1407,6 +1407,22 @@ class Sequence(BaseTestCase):
         s.clear()
         assert s.getComponentByPosition(1, default=None) is None
 
+    def testGetComponentWithConstructedDefault(self):
+
+        class Sequence(univ.Sequence):
+            componentType = namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString()),
+                namedtype.DefaultedNamedType('nick', univ.SequenceOf(
+                    componentType=univ.Integer()
+                ).setComponentByPosition(0, 1)),
+            )
+
+        s = Sequence()
+
+        assert s.getComponentByPosition(1, default=None, instantiate=False) is None
+        assert s.getComponentByPosition(1, instantiate=False) is univ.noValue
+        assert s.getComponentByPosition(1) == [1]
+
     def testGetComponentNoInstantiation(self):
 
         class Sequence(univ.Sequence):


### PR DESCRIPTION
When SEQUENCE has defaulted component of constructed type, recursively instantiate defaulted component and assign instantiated asn1 object to SEQUENCE field.