### PR TITLE
Fix `AnyDecoder` to accept `TagMap` as `asn1Spec`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Revision 0.4.6, released XX-06-2019
   becomes a value object.
 - Added `.reset()` method to all constructed types to turn value object
   into a schema object.
+- Fixed `AnyDecoder` to accept possible `TagMap` as `asn1Spec`
+  to make dumping raw value operational
 
 Revision 0.4.5, released 29-12-2018
 -----------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,9 @@
 Revision 0.4.6, released XX-01-2019
 -----------------------------------
 
-No changes yet
+- Added `omitEmptyOptionals` option which is respected by `Sequence`
+  and `Set` encoders. When `omitEmptyOptionals` is set to `True`, empty
+  initialized optional components are not encoded. Default is `False`.
 
 Revision 0.4.5, released 29-12-2018
 -----------------------------------

--- a/tests/codec/ber/test_decoder.py
+++ b/tests/codec/ber/test_decoder.py
@@ -1429,6 +1429,38 @@ class NonStringDecoderTestCase(BaseTestCase):
         assert self.s == s
 
 
+class ErrorOnDecodingTestCase(BaseTestCase):
+
+    def testErrorCondition(self):
+        decode = decoder.Decoder(decoder.tagMap, decoder.typeMap)
+
+        try:
+            asn1Object, rest = decode(str2octs('abc'))
+
+        except PyAsn1Error:
+            exc = sys.exc_info()[1]
+            assert (isinstance(exc, PyAsn1Error),
+                    'Unexpected exception raised %r' % (exc,))
+
+        else:
+            assert False, 'Unexpected decoder result %r' % (asn1Object,)
+
+    def testRawDump(self):
+        decode = decoder.Decoder(decoder.tagMap, decoder.typeMap)
+
+        decode.defaultErrorState = decoder.stDumpRawValue
+
+        asn1Object, rest = decode(ints2octs(
+            (31, 8, 2, 1, 1, 131, 3, 2, 1, 12)))
+
+        assert (isinstance(asn1Object, univ.Any),
+                'Unexpected raw dump type %r' % (asn1Object,))
+        assert (asn1Object.asNumbers() == (31, 8, 2, 1, 1),
+                'Unexpected raw dump value %r' % (asn1Object,))
+        assert (rest == ints2octs((131, 3, 2, 1, 12)),
+                'Unexpected rest of substrate after raw dump %r' % rest)
+
+
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 
 if __name__ == '__main__':


### PR DESCRIPTION
The use-case is to make `AnyDecoder` operational when dumping
raw value on error condition is enabled