### PR TITLE
Add specific exceptions for String issues

### DIFF
--- a/pyasn1/error.py
+++ b/pyasn1/error.py
@@ -19,6 +19,10 @@ class PyAsn1StringError(PyAsn1Error, UnicodeError):
     The `PyAsn1StringError` exception is a base class for errors relating to
     string encoding/decoding and other related problems
     """
+    def __init__(self, message, unicode_error=None):
+        if isinstance(unicode_error, UnicodeError):
+            UnicodeError.__init__(self, *unicode_error.args)
+        PyAsn1Error.__init__(self, message)
 
 
 class PyAsn1StringDecodeError(PyAsn1StringError, UnicodeDecodeError):

--- a/pyasn1/error.py
+++ b/pyasn1/error.py
@@ -13,6 +13,22 @@ class PyAsn1Error(Exception):
     """
 
 
+class PyAsn1StringDecodeError(PyAsn1Error, UnicodeDecodeError):
+    """Create pyasn1 exception object
+
+    The `PyAsn1StringDecodeError` exception represents a failure to decode
+    underlying bytes values to a string
+    """
+
+
+class PyAsn1StringEncodeError(PyAsn1Error, UnicodeEncodeError):
+    """Create pyasn1 exception object
+
+    The `PyAsn1StringEncodeError` exception represents a failure to encode
+    underlying string value as bytes
+    """
+
+
 class ValueConstraintError(PyAsn1Error):
     """Create pyasn1 exception object
 

--- a/pyasn1/error.py
+++ b/pyasn1/error.py
@@ -13,7 +13,7 @@ class PyAsn1Error(Exception):
     """
 
 
-class PyAsn1StringError(PyAsn1Error):
+class PyAsn1StringError(PyAsn1Error, UnicodeError):
     """Create pyasn1 exception object
 
     The `PyAsn1StringError` exception is a base class for errors relating to

--- a/pyasn1/error.py
+++ b/pyasn1/error.py
@@ -13,7 +13,15 @@ class PyAsn1Error(Exception):
     """
 
 
-class PyAsn1StringDecodeError(PyAsn1Error, UnicodeDecodeError):
+class PyAsn1StringError(PyAsn1Error):
+    """Create pyasn1 exception object
+
+    The `PyAsn1StringError` exception is a base class for errors relating to
+    string encoding/decoding and other related problems
+    """
+
+
+class PyAsn1StringDecodeError(PyAsn1StringError, UnicodeDecodeError):
     """Create pyasn1 exception object
 
     The `PyAsn1StringDecodeError` exception represents a failure to decode
@@ -21,7 +29,7 @@ class PyAsn1StringDecodeError(PyAsn1Error, UnicodeDecodeError):
     """
 
 
-class PyAsn1StringEncodeError(PyAsn1Error, UnicodeEncodeError):
+class PyAsn1StringEncodeError(PyAsn1StringError, UnicodeEncodeError):
     """Create pyasn1 exception object
 
     The `PyAsn1StringEncodeError` exception represents a failure to encode

--- a/pyasn1/type/char.py
+++ b/pyasn1/type/char.py
@@ -54,9 +54,9 @@ class AbstractCharacterString(univ.OctetString):
                 # `str` is Py2 text representation
                 return self._value.encode(self.encoding)
 
-            except UnicodeEncodeError:
+            except UnicodeEncodeError as e:
                 raise error.PyAsn1StringEncodeError(
-                    "Can't encode string '%s' with codec %s" % (self._value, self.encoding)
+                    "Can't encode string '%s' with codec %s" % (self._value, self.encoding), e
                 )
 
         def __unicode__(self):
@@ -75,9 +75,9 @@ class AbstractCharacterString(univ.OctetString):
                 else:
                     return unicode(value)
 
-            except (UnicodeDecodeError, LookupError):
+            except (UnicodeDecodeError, LookupError) as e:
                 raise error.PyAsn1StringDecodeError(
-                    "Can't decode string '%s' with codec %s" % (value, self.encoding)
+                    "Can't decode string '%s' with codec %s" % (value, self.encoding), e
                 )
 
         def asOctets(self, padding=True):
@@ -94,9 +94,9 @@ class AbstractCharacterString(univ.OctetString):
         def __bytes__(self):
             try:
                 return self._value.encode(self.encoding)
-            except UnicodeEncodeError:
+            except UnicodeEncodeError as e:
                 raise error.PyAsn1StringEncodeError(
-                    "Can't encode string '%s' with codec %s" % (self._value, self.encoding)
+                    "Can't encode string '%s' with codec %s" % (self._value, self.encoding), e
                 )
 
         def prettyIn(self, value):
@@ -112,9 +112,9 @@ class AbstractCharacterString(univ.OctetString):
                 else:
                     return str(value)
 
-            except (UnicodeDecodeError, LookupError):
+            except (UnicodeDecodeError, LookupError) as e:
                 raise error.PyAsn1StringDecodeError(
-                    "Can't decode string '%s' with codec %s" % (value, self.encoding)
+                    "Can't decode string '%s' with codec %s" % (value, self.encoding), e
                 )
 
         def asOctets(self, padding=True):

--- a/pyasn1/type/char.py
+++ b/pyasn1/type/char.py
@@ -55,7 +55,7 @@ class AbstractCharacterString(univ.OctetString):
                 return self._value.encode(self.encoding)
 
             except UnicodeEncodeError:
-                raise error.PyAsn1Error(
+                raise error.PyAsn1StringEncodeError(
                     "Can't encode string '%s' with codec %s" % (self._value, self.encoding)
                 )
 
@@ -76,7 +76,7 @@ class AbstractCharacterString(univ.OctetString):
                     return unicode(value)
 
             except (UnicodeDecodeError, LookupError):
-                raise error.PyAsn1Error(
+                raise error.PyAsn1StringDecodeError(
                     "Can't decode string '%s' with codec %s" % (value, self.encoding)
                 )
 
@@ -95,7 +95,7 @@ class AbstractCharacterString(univ.OctetString):
             try:
                 return self._value.encode(self.encoding)
             except UnicodeEncodeError:
-                raise error.PyAsn1Error(
+                raise error.PyAsn1StringEncodeError(
                     "Can't encode string '%s' with codec %s" % (self._value, self.encoding)
                 )
 
@@ -113,7 +113,7 @@ class AbstractCharacterString(univ.OctetString):
                     return str(value)
 
             except (UnicodeDecodeError, LookupError):
-                raise error.PyAsn1Error(
+                raise error.PyAsn1StringDecodeError(
                     "Can't decode string '%s' with codec %s" % (value, self.encoding)
                 )
 

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -825,9 +825,9 @@ class OctetString(base.AbstractSimpleAsn1Item):
             elif isinstance(value, unicode):
                 try:
                     return value.encode(self.encoding)
-                except (LookupError, UnicodeEncodeError):
+                except (LookupError, UnicodeEncodeError) as e:
                     raise error.PyAsn1StringEncodeError(
-                        "Can't encode string '%s' with codec %s" % (value, self.encoding)
+                        "Can't encode string '%s' with codec %s" % (value, self.encoding), e
                     )
             elif isinstance(value, (tuple, list)):
                 try:
@@ -846,9 +846,9 @@ class OctetString(base.AbstractSimpleAsn1Item):
             try:
                 return self._value.decode(self.encoding)
 
-            except UnicodeDecodeError:
+            except UnicodeDecodeError as e:
                 raise error.PyAsn1StringDecodeError(
-                    "Can't decode string '%s' with codec %s" % (self._value, self.encoding)
+                    "Can't decode string '%s' with codec %s" % (self._value, self.encoding), e
                 )
 
         def asOctets(self):
@@ -864,9 +864,9 @@ class OctetString(base.AbstractSimpleAsn1Item):
             elif isinstance(value, str):
                 try:
                     return value.encode(self.encoding)
-                except UnicodeEncodeError:
+                except UnicodeEncodeError as e:
                     raise error.PyAsn1StringEncodeError(
-                        "Can't encode string '%s' with '%s' codec" % (value, self.encoding)
+                        "Can't encode string '%s' with '%s' codec" % (value, self.encoding), e
                     )
             elif isinstance(value, OctetString):  # a shortcut, bytes() would work the same way
                 return value.asOctets()
@@ -881,9 +881,9 @@ class OctetString(base.AbstractSimpleAsn1Item):
             try:
                 return self._value.decode(self.encoding)
 
-            except UnicodeDecodeError:
+            except UnicodeDecodeError as e:
                 raise error.PyAsn1StringDecodeError(
-                    "Can't decode string '%s' with '%s' codec at '%s'" % (self._value, self.encoding, self.__class__.__name__)
+                    "Can't decode string '%s' with '%s' codec at '%s'" % (self._value, self.encoding, self.__class__.__name__), e
                 )
 
         def __bytes__(self):

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -826,7 +826,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
                 try:
                     return value.encode(self.encoding)
                 except (LookupError, UnicodeEncodeError):
-                    raise error.PyAsn1StringError(
+                    raise error.PyAsn1StringEncodeError(
                         "Can't encode string '%s' with codec %s" % (value, self.encoding)
                     )
             elif isinstance(value, (tuple, list)):
@@ -847,7 +847,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
                 return self._value.decode(self.encoding)
 
             except UnicodeDecodeError:
-                raise error.PyAsn1StringError(
+                raise error.PyAsn1StringDecodeError(
                     "Can't decode string '%s' with codec %s" % (self._value, self.encoding)
                 )
 
@@ -865,7 +865,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
                 try:
                     return value.encode(self.encoding)
                 except UnicodeEncodeError:
-                    raise error.PyAsn1StringError(
+                    raise error.PyAsn1StringEncodeError(
                         "Can't encode string '%s' with '%s' codec" % (value, self.encoding)
                     )
             elif isinstance(value, OctetString):  # a shortcut, bytes() would work the same way
@@ -882,7 +882,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
                 return self._value.decode(self.encoding)
 
             except UnicodeDecodeError:
-                raise error.PyAsn1StringError(
+                raise error.PyAsn1StringDecodeError(
                     "Can't decode string '%s' with '%s' codec at '%s'" % (self._value, self.encoding, self.__class__.__name__)
                 )
 

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -826,7 +826,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
                 try:
                     return value.encode(self.encoding)
                 except (LookupError, UnicodeEncodeError):
-                    raise error.PyAsn1Error(
+                    raise error.PyAsn1StringError(
                         "Can't encode string '%s' with codec %s" % (value, self.encoding)
                     )
             elif isinstance(value, (tuple, list)):
@@ -847,7 +847,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
                 return self._value.decode(self.encoding)
 
             except UnicodeDecodeError:
-                raise error.PyAsn1Error(
+                raise error.PyAsn1StringError(
                     "Can't decode string '%s' with codec %s" % (self._value, self.encoding)
                 )
 
@@ -865,7 +865,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
                 try:
                     return value.encode(self.encoding)
                 except UnicodeEncodeError:
-                    raise error.PyAsn1Error(
+                    raise error.PyAsn1StringError(
                         "Can't encode string '%s' with '%s' codec" % (value, self.encoding)
                     )
             elif isinstance(value, OctetString):  # a shortcut, bytes() would work the same way
@@ -882,7 +882,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
                 return self._value.decode(self.encoding)
 
             except UnicodeDecodeError:
-                raise error.PyAsn1Error(
+                raise error.PyAsn1StringError(
                     "Can't decode string '%s' with '%s' codec at '%s'" % (self._value, self.encoding, self.__class__.__name__)
                 )
 


### PR DESCRIPTION
My application can expect either raw bytes or a string in the same underlying ASN1 components. The current exception hierarchy makes this situation basically impossible to handle.

I have added new exceptions specific to string encoding and decoding, and utilized multiple inheritance to ensure that users catching any relevant type of error will still catch these errors. i.e. users that have updated their code to catch `PyAsn1Error` in this situation can continue doing so unaffected, and users that were already catching the `Unicode*Error`s and have not updated will be fixed with this patch.

Also worth noting that Python `.encode()` and `.decode()` will always use the relevant `Unicode*Error` regardless of the passed encoding.