### PR TITLE
Remove invalid escape sequences to get rid of Py3 DeprecationWarning

### DIFF
--- a/pyasn1/type/constraint.py
+++ b/pyasn1/type/constraint.py
@@ -107,7 +107,7 @@ class SingleValueConstraint(AbstractConstraint):
 
     Parameters
     ----------
-    \*values: :class:`int`
+    *values: :class:`int`
         Full set of values permitted by this constraint object.
 
     Examples
@@ -149,7 +149,7 @@ class ContainedSubtypeConstraint(AbstractConstraint):
 
     Parameters
     ----------
-    \*values:
+    *values:
         Full set of values and constraint objects permitted
         by this constraint object.
 
@@ -310,7 +310,7 @@ class PermittedAlphabetConstraint(SingleValueConstraint):
 
     Parameters
     ----------
-    \*alphabet: :class:`str`
+    *alphabet: :class:`str`
         Full set of characters permitted by this constraint object.
 
     Examples
@@ -467,7 +467,7 @@ class ConstraintsIntersection(AbstractConstraintSet):
 
     Parameters
     ----------
-    \*constraints:
+    *constraints:
         Constraint or logic operator objects.
 
     Examples
@@ -511,7 +511,7 @@ class ConstraintsUnion(AbstractConstraintSet):
 
     Parameters
     ----------
-    \*constraints:
+    *constraints:
         Constraint or logic operator objects.
 
     Examples

--- a/pyasn1/type/namedval.py
+++ b/pyasn1/type/namedval.py
@@ -23,7 +23,7 @@ class NamedValues(object):
 
     Parameters
     ----------
-    \*args: variable number of two-element :py:class:`tuple`
+    *args: variable number of two-element :py:class:`tuple`
 
         name: :py:class:`str`
             Value label


### PR DESCRIPTION
The backslashes seem unnecessary and they're causing deprecation warnings that look like:
pyasn1/type/constraint.py:130: DeprecationWarning: invalid escape sequence \*