### PR TITLE
SequenceOf/SetOf to remain a schema objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,9 @@
 Revision 0.4.6, released XX-01-2019
 -----------------------------------
 
-No changes yet
+- Added `omitEmptyOptionals` option which is respected by `Sequence`
+  and `Set` encoders. When `omitEmptyOptionals` is set to `True`, empty
+  initialized optional components are not encoded. Default is `False`.
 
 Revision 0.4.5, released 29-12-2018
 -----------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,31 @@
 
-Revision 0.4.6, released XX-01-2019
+Revision 0.4.6, released XX-06-2019
 -----------------------------------
 
 - Added `omitEmptyOptionals` option which is respected by `Sequence`
   and `Set` encoders. When `omitEmptyOptionals` is set to `True`, empty
   initialized optional components are not encoded. Default is `False`.
+- New elements to `SequenceOf`/`SetOf` objects can now be added at any
+  position - the requirement for the new elements to reside at the end
+  of the existing ones (i.e. s[len(s)] = 123) is removed.
+- Removed default initializer from `SequenceOf`/`SetOf` types to ensure
+  consistent behaviour with the rest of ASN.1 types. Before this change,
+  `SequenceOf`/`SetOf` instances immediately become value objects behaving
+  like an empty list. With this change, `SequenceOf`/`SetOf` objects
+  remain schema objects unless a component is added or `.clear()` is
+  called.
+  This change can potentially cause incompatibilities with existing
+  pyasn1 objects which assume `SequenceOf`/`SetOf` instances are value
+  objects right upon instantiation.
+  The behaviour of `Sequence`/`Set` types depends on the `componentType`
+  initializer: if on `componentType` is given, the behaviour is the
+  same as `SequenceOf`/`SetOf` have. IF `componentType` is given, but
+  neither optional nor defaulted components are present, the created
+  instance remains schema object, If, however, either optional or
+  defaulted component isi present, the created instance immediately
+  becomes a value object.
+- Added `.reset()` method to all constructed types to turn value object
+  into a schema object.
 
 Revision 0.4.5, released 29-12-2018
 -----------------------------------

--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -567,6 +567,7 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
             return asn1Object, tail
 
         asn1Object = asn1Spec.clone()
+        asn1Object.clear()
 
         if asn1Spec.typeId in (univ.Sequence.typeId, univ.Set.typeId):
 
@@ -682,6 +683,7 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
 
         else:
             asn1Object = asn1Spec.clone()
+            asn1Object.clear()
 
             componentType = asn1Spec.componentType
 
@@ -727,6 +729,7 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
             )
 
         asn1Object = asn1Spec.clone()
+        asn1Object.clear()
 
         if asn1Spec.typeId in (univ.Sequence.typeId, univ.Set.typeId):
 
@@ -847,6 +850,7 @@ class UniversalConstructedTypeDecoder(AbstractConstructedDecoder):
 
         else:
             asn1Object = asn1Spec.clone()
+            asn1Object.clear()
 
             componentType = asn1Spec.componentType
 

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -467,8 +467,6 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
 
         Asn1ItemBase.__init__(self, **readOnly)
 
-        self._componentValues = []
-
     def __repr__(self):
         representation = '%s %s object at 0x%x' % (
             self.__class__.__name__, self.isValue and 'value' or 'schema', id(self)
@@ -478,38 +476,40 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
             if value is not noValue:
                 representation += ' %s=%r' % (attr, value)
 
-        if self.isValue and self._componentValues:
-            representation += ' payload [%s]' % ', '.join([repr(x) for x in self._componentValues])
+        if self.isValue and self.components:
+            representation += ' payload [%s]' % ', '.join(
+                [repr(x) for x in self.components])
 
         return '<%s>' % representation
 
     def __eq__(self, other):
-        return self is other and True or self._componentValues == other
+        return self is other or self.components == other
 
     def __ne__(self, other):
-        return self._componentValues != other
+        return self.components != other
 
     def __lt__(self, other):
-        return self._componentValues < other
+        return self.components < other
 
     def __le__(self, other):
-        return self._componentValues <= other
+        return self.components <= other
 
     def __gt__(self, other):
-        return self._componentValues > other
+        return self.components > other
 
     def __ge__(self, other):
-        return self._componentValues >= other
+        return self.components >= other
 
     if sys.version_info[0] <= 2:
         def __nonzero__(self):
-            return self._componentValues and True or False
+            return bool(self.components)
     else:
         def __bool__(self):
-            return self._componentValues and True or False
+            return bool(self.components)
 
-    def __len__(self):
-        return len(self._componentValues)
+    @property
+    def components(self):
+        raise error.PyAsn1Error('Method not implemented')
 
     def _cloneComponentValues(self, myClone, cloneValueFlag):
         pass
@@ -630,9 +630,6 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
         for k in kwargs:
             self[k] = kwargs[k]
         return self
-
-    def clear(self):
-        self._componentValues = []
 
     # backward compatibility
 

--- a/tests/codec/ber/test_encoder.py
+++ b/tests/codec/ber/test_encoder.py
@@ -476,6 +476,7 @@ class UTF8StringEncoderWithSchemaTestCase(BaseTestCase):
 class SequenceOfEncoderTestCase(BaseTestCase):
     def testEmpty(self):
         s = univ.SequenceOf()
+        s.clear()
         assert encoder.encode(s) == ints2octs((48, 0))
 
     def testDefMode(self):
@@ -570,6 +571,7 @@ class SequenceOfEncoderWithComponentsSchemaTestCase(BaseTestCase):
 class SetOfEncoderTestCase(BaseTestCase):
     def testEmpty(self):
         s = univ.SetOf()
+        s.clear()
         assert encoder.encode(s) == ints2octs((49, 0))
 
     def testDefMode(self):

--- a/tests/codec/cer/test_encoder.py
+++ b/tests/codec/cer/test_encoder.py
@@ -155,6 +155,7 @@ class UTCTimeEncoderTestCase(BaseTestCase):
 class SequenceOfEncoderTestCase(BaseTestCase):
     def testEmpty(self):
         s = univ.SequenceOf()
+        s.clear()
         assert encoder.encode(s) == ints2octs((48, 128, 0, 0))
 
     def testDefMode1(self):
@@ -219,6 +220,7 @@ class SequenceOfEncoderWithSchemaTestCase(BaseTestCase):
 class SetOfEncoderTestCase(BaseTestCase):
     def testEmpty(self):
         s = univ.SetOf()
+        s.clear()
         assert encoder.encode(s) == ints2octs((49, 128, 0, 0))
 
     def testDefMode1(self):


### PR DESCRIPTION
    - New elements to `SequenceOf`/`SetOf` objects can now be added at any
      position - the requirement for the new elements to reside at the end
      of the existing ones (i.e. s[len(s)] = 123) is removed.
    
    - Removed default initializer from `SequenceOf`/`SetOf` types to ensure
      consistent behaviour with the rest of ASN.1 types. Before this change,
      `SequenceOf`/`SetOf` instances immediately become value objects
      behaving like an empty list. With this change, `SequenceOf`/`SetOf`
      objects remain schema objects unless a component is added or
      `.clear()` is called.
    
    - Added `.reset()` method to all constructed types to turn value object
      into a schema object.
