### PR TITLE
Add support for Python 3.8, drop EOL 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then (make -C docs html); fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then (make -C docs html); fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then (make -C docs html); fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.8' ]]; then (make -C docs html); fi
   - if [[ $TRAVIS_PYTHON_VERSION == 'nightly' ]]; then (make -C docs html); fi
 after_success:
   - PYTHONPATH=.:$PYTHONPATH coverage run --omit=*test* tests/__main__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,13 @@ language: python
 cache: pip
 matrix:
   include:
-  - os: linux
-    dist: trusty
-    python: '2.7'
-  - os: linux
-    dist: trusty
-    python: '3.5'
-  - os: linux
-    dist: trusty
-    python: '3.6'
-  - os: linux
-    dist: xenial
-    python: '3.7'
-  - os: linux
-    dist: trusty
-    python: 'nightly'
-  - os: linux
-    dist: trusty
-    python: 'pypy'
-  - os: linux
-    dist: trusty
-    python: 'pypy3'
+  - python: '2.7'
+  - python: '3.5'
+  - python: '3.6'
+  - python: '3.7'
+  - python: 'nightly'
+  - python: 'pypy'
+  - python: 'pypy3'
 install:
   - pip install codecov
   - pip install -r requirements.txt -r devel-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ matrix:
     python: '2.7'
   - os: linux
     dist: trusty
-    python: '3.4'
-  - os: linux
-    dist: trusty
     python: '3.5'
   - os: linux
     dist: trusty
@@ -32,10 +29,7 @@ install:
   - pip install -e .
 script:
   - PYTHONPATH=.:$PYTHONPATH python tests/__main__.py
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then (make -C docs html); fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then (make -C docs html); fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then (make -C docs html); fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then (make -C docs html); fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then (make -C docs html); fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then (make -C docs html); fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then (make -C docs html); fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,8 @@
 Revision 0.5.0, released XX-11-2019
 -----------------------------------
 
-- Removed support for EOL Pythons 2.4, 2.5, 2.6, 3.2 and 3.3.
+- Added support for Python 3.8.
+- Removed support for EOL Pythons 2.4, 2.5, 2.6, 3.2, 3.3 and 3.4.
 
 Revision 0.4.8, released 16-11-2019
 -----------------------------------

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Features
 * Generic implementation of ASN.1 types (X.208)
 * Standards compliant BER/CER/DER codecs
 * Dumps/loads ASN.1 structures from Python types
-* 100% Python, works with Python 2.7 and 3.4+
+* 100% Python, works with Python 2.7 and 3.5+
 * MT-safe
 * Contributed ASN.1 compiler [Asn1ate](https://github.com/kimgr/asn1ate)
 

--- a/pyasn1/compat/integer.py
+++ b/pyasn1/compat/integer.py
@@ -12,11 +12,8 @@ from pyasn1.compat.octets import oct2int, null, ensureString
 
 implementation = platform.python_implementation()
 
-if sys.version_info[0:2] < (3, 2) or implementation != 'CPython':
+if sys.version_info[0] < 3 or implementation != 'CPython':
     from binascii import a2b_hex, b2a_hex
-
-    if sys.version_info[0] > 2:
-        long = int
 
     def from_bytes(octets, signed=False):
         if not octets:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ Operating System :: OS Independent
 Programming Language :: Python :: 2
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
@@ -85,7 +84,7 @@ params.update({
                  'pyasn1.codec.cer',
                  'pyasn1.codec.der',
                  'pyasn1.codec.native'],
-    'python_requires': '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'})
+    'python_requires': '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*'})
 
 
 class PyTest(Command):

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
 Topic :: Communications
 Topic :: Software Development :: Libraries :: Python Modules
 """

--- a/tests/codec/ber/test_decoder.py
+++ b/tests/codec/ber/test_decoder.py
@@ -480,7 +480,7 @@ class RealDecoderTestCase(BaseTestCase):
 
 class UniversalStringDecoderTestCase(BaseTestCase):
     def testDecoder(self):
-        assert decoder.decode(ints2octs((28, 12, 0, 0, 0, 97, 0, 0, 0, 98, 0, 0, 0, 99))) == (char.UniversalString(sys.version_info[0] == 3 and 'abc' or unicode('abc')), null)
+        assert decoder.decode(ints2octs((28, 12, 0, 0, 0, 97, 0, 0, 0, 98, 0, 0, 0, 99))) == (char.UniversalString(sys.version_info[0] >= 3 and 'abc' or unicode('abc')), null)
 
 
 class BMPStringDecoderTestCase(BaseTestCase):

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -143,20 +143,10 @@ class NoValueTestCase(BaseTestCase):
     
     def testSizeOf(self):
         try:
-            if hasattr(sys, 'getsizeof'):
-                sys.getsizeof(univ.noValue)
-
-            # TODO: remove when Py2.5 support is gone
-            elif sys.version_info > (2, 6):
-                raise unittest.SkipTest("no sys.getsizeof() method")
+            sys.getsizeof(univ.noValue)
 
         except PyAsn1Error:
             assert False, 'sizeof failed for NoValue object'
-
-        except TypeError:
-            # TODO: remove when Py2.5 support is gone
-            if sys.version_info > (2, 6):
-                raise unittest.SkipTest("sys.getsizeof() raises TypeError")
 
 
 class IntegerTestCase(BaseTestCase):
@@ -557,11 +547,6 @@ class OctetStringUnicodeErrorTestCase(BaseTestCase):
         except PyAsn1UnicodeEncodeError:
             pass
 
-        # TODO: remove when Py2.5 support is gone
-        else:
-            if sys.version_info > (2, 6):
-                assert False, 'Unicode encoding error not caught'
-
     def testDecodeError(self):
         serialized = ints2octs((0xff, 0xfe))
 
@@ -576,11 +561,6 @@ class OctetStringUnicodeErrorTestCase(BaseTestCase):
 
         except PyAsn1UnicodeDecodeError:
             pass
-
-        # TODO: remove when Py2.5 support is gone
-        else:
-            if sys.version_info > (2, 6):
-                assert False, 'Unicode decoding error not caught'
 
 
 class OctetStringWithUtf8TestCase(OctetStringWithUnicodeMixIn, BaseTestCase):


### PR DESCRIPTION
Follow on from https://github.com/etingof/pyasn1/pull/131.

* 3.8 was released on 2019-10-14
* 3.4 was EOL on 2019-03-16
