### PR TITLE
Raise exceptions in consistency check

### DIFF
--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -824,9 +824,7 @@ class ConstructedPayloadDecoderBase(AbstractConstructedPayloadDecoder):
                                 asn1Object.setComponentByPosition(idx, component)
 
             else:
-                inconsistency = asn1Object.isInconsistent
-                if inconsistency:
-                    raise inconsistency
+                asn1Object.checkConsistency()
 
         else:
             componentType = asn1Spec.componentType
@@ -1049,9 +1047,7 @@ class ConstructedPayloadDecoderBase(AbstractConstructedPayloadDecoder):
                                     asn1Object.setComponentByPosition(idx, component)
 
                 else:
-                    inconsistency = asn1Object.isInconsistent
-                    if inconsistency:
-                        raise inconsistency
+                    asn1Object.checkConsistency()
 
         else:
             componentType = asn1Spec.componentType

--- a/pyasn1/codec/ber/encoder.py
+++ b/pyasn1/codec/ber/encoder.py
@@ -537,9 +537,7 @@ class SequenceEncoder(AbstractItemEncoder):
 
         if asn1Spec is None:
             # instance of ASN.1 schema
-            inconsistency = value.isInconsistent
-            if inconsistency:
-                raise inconsistency
+            value.checkConsistency()
 
             namedTypes = value.componentType
 
@@ -645,9 +643,7 @@ class SequenceOfEncoder(AbstractItemEncoder):
     def _encodeComponents(self, value, asn1Spec, encodeFun, **options):
 
         if asn1Spec is None:
-            inconsistency = value.isInconsistent
-            if inconsistency:
-                raise inconsistency
+            value.checkConsistency()
 
         else:
             asn1Spec = asn1Spec.componentType

--- a/pyasn1/codec/cer/encoder.py
+++ b/pyasn1/codec/cer/encoder.py
@@ -169,9 +169,7 @@ class SetEncoder(encoder.SequenceEncoder):
 
         if asn1Spec is None:
             # instance of ASN.1 schema
-            inconsistency = value.isInconsistent
-            if inconsistency:
-                raise inconsistency
+            value.checkConsistency()
 
             namedTypes = value.componentType
 
@@ -180,10 +178,10 @@ class SetEncoder(encoder.SequenceEncoder):
                     namedType = namedTypes[idx]
 
                     if namedType.isOptional and not component.isValue:
-                            continue
+                        continue
 
                     if namedType.isDefaulted and component == namedType.asn1Object:
-                            continue
+                        continue
 
                     compsMap[id(component)] = namedType
 

--- a/pyasn1/codec/native/encoder.py
+++ b/pyasn1/codec/native/encoder.py
@@ -68,9 +68,7 @@ class SetEncoder(AbstractItemEncoder):
     protoDict = dict
 
     def encode(self, value, encodeFun, **options):
-        inconsistency = value.isInconsistent
-        if inconsistency:
-            raise inconsistency
+        value.checkConsistency()
 
         namedTypes = value.componentType
         substrate = self.protoDict()
@@ -88,9 +86,7 @@ class SequenceEncoder(SetEncoder):
 
 class SequenceOfEncoder(AbstractItemEncoder):
     def encode(self, value, encodeFun, **options):
-        inconsistency = value.isInconsistent
-        if inconsistency:
-            raise inconsistency
+        value.checkConsistency()
         return [encodeFun(x, **options) for x in value]
 
 

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -2033,8 +2033,8 @@ class SequenceOfAndSetOfBase(base.ConstructedAsn1Type):
         Default action is to verify |ASN.1| object against constraints imposed
         by `subtypeSpec`.
 
-        Raises
-        ------
+        Returns
+        -------
         :py:class:`~pyasn1.error.PyAsn1tError` on any inconsistencies found
         """
         if self.componentType is noValue or not self.subtypeSpec:
@@ -2061,6 +2061,17 @@ class SequenceOfAndSetOfBase(base.ConstructedAsn1Type):
             return exc
 
         return False
+
+    def checkConsistency(self):
+        """
+        Raises
+        ------
+        :py:class:`~pyasn1.error.PyAsn1tError` on any inconsistencies found
+        """
+        inconsistency = self.isInconsistent
+        if isinstance(inconsistency, Exception):
+            raise inconsistency
+
 
 class SequenceOf(SequenceOfAndSetOfBase):
     __doc__ = SequenceOfAndSetOfBase.__doc__
@@ -2663,8 +2674,8 @@ class SequenceAndSetBase(base.ConstructedAsn1Type):
         Default action is to verify |ASN.1| object against constraints imposed
         by `subtypeSpec`.
 
-        Raises
-        ------
+        Returns
+        -------
         :py:class:`~pyasn1.error.PyAsn1tError` on any inconsistencies found
         """
         if self.componentType is noValue or not self.subtypeSpec:
@@ -2693,6 +2704,16 @@ class SequenceAndSetBase(base.ConstructedAsn1Type):
             return exc
 
         return False
+
+    def checkConsistency(self):
+        """
+        Raises
+        ------
+        :py:class:`~pyasn1.error.PyAsn1tError` on any inconsistencies found
+        """
+        inconsistency = self.isInconsistent
+        if isinstance(inconsistency, Exception):
+            raise inconsistency
 
     def prettyPrint(self, scope=0):
         """Return an object representation string.


### PR DESCRIPTION
isInconsistent can return a boolean, add a new wrapper which checks the
return type and use that instead.

Fixes #178